### PR TITLE
quick fix to init state when value has been passed by props

### DIFF
--- a/packages/Textarea/src/index.tsx
+++ b/packages/Textarea/src/index.tsx
@@ -2,6 +2,7 @@ import withUtils from "@blaze-react/utils";
 import React, {
   FunctionComponent,
   TextareaHTMLAttributes,
+  useEffect,
   useState
 } from "react";
 interface ITextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -30,6 +31,12 @@ const Textarea: FunctionComponent<ITextareaProps> = ({
   ...attrs
 }) => {
   const [content, setContent] = useState<string>("");
+
+  useEffect((): void => {
+    if (!content && value) {
+      setContent(value);
+    }
+  }, []);
 
   const handleChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>


### PR DESCRIPTION
Value was passed by props but ignored, now when component has been initialized we are setting value as content to be rendered in textarea.