### PR TITLE
Bz2 badge colours

### DIFF
--- a/packages/Badge/src/index.tsx
+++ b/packages/Badge/src/index.tsx
@@ -1,10 +1,8 @@
-import React, { FunctionComponent } from "react";
+import React, { Fragment, FunctionComponent } from "react";
 interface IBadgeProps {
   type?: string;
   to?: string;
-  round?: boolean;
   link?: boolean;
-  pill?: boolean;
   icon?: boolean;
   color?: string;
   children?: string | JSX.Element;
@@ -21,9 +19,7 @@ const Badge: FunctionComponent<IBadgeProps> = ({
   const withIcon = icon ? "badge--icon-text" : "";
   const classes = `badge ${type} ${withIcon} ${color}`;
   return link ? (
-    <a href={to} className={classes} {...attrs}>
-      {children}
-    </a>
+    <Fragment> {children}</Fragment>
   ) : (
     <span className={classes} {...attrs}>
       {children}
@@ -35,7 +31,6 @@ Badge.defaultProps = {
   icon: false,
   link: false,
   to: "#",
-  color: "grey-dark",
-  type: "badge--pagebuilder"
+  color: "grey-dark"
 };
 export default Badge;

--- a/packages/Badge/src/index.tsx
+++ b/packages/Badge/src/index.tsx
@@ -13,33 +13,27 @@ const Badge: FunctionComponent<IBadgeProps> = ({
   children,
   type,
   color,
-  pill,
   icon,
-  round,
   to,
   link,
   ...attrs
 }) => {
-  const isPill = pill ? "badge--pill" : "";
-  const isRound = round ? "badge--round" : "";
   const withIcon = icon ? "badge--icon-text" : "";
-  const classes = `badge ${color} ${isRound} ${isPill} ${withIcon} ${type}`;
+  const classes = `badge ${type} ${withIcon} ${color}`;
   return link ? (
     <a href={to} className={classes} {...attrs}>
       {children}
     </a>
   ) : (
-      <span className={classes} {...attrs}>
-        {children}
-      </span>
-    );
+    <span className={classes} {...attrs}>
+      {children}
+    </span>
+  );
 };
 Badge.defaultProps = {
   children: "No content",
   icon: false,
   link: false,
-  pill: false,
-  round: false,
   to: "#",
   color: "grey-dark",
   type: "badge--pagebuilder"

--- a/packages/Badge/src/index.tsx
+++ b/packages/Badge/src/index.tsx
@@ -6,11 +6,13 @@ interface IBadgeProps {
   link?: boolean;
   pill?: boolean;
   icon?: boolean;
+  color?: string;
   children?: string | JSX.Element;
 }
 const Badge: FunctionComponent<IBadgeProps> = ({
   children,
   type,
+  color,
   pill,
   icon,
   round,
@@ -18,20 +20,19 @@ const Badge: FunctionComponent<IBadgeProps> = ({
   link,
   ...attrs
 }) => {
-  const assignType = type ? `badge--${type}` : "";
   const isPill = pill ? "badge--pill" : "";
   const isRound = round ? "badge--round" : "";
   const withIcon = icon ? "badge--icon-text" : "";
-  const classes = `badge ${assignType} ${isRound} ${isPill} ${withIcon}`;
+  const classes = `badge ${color} ${isRound} ${isPill} ${withIcon} ${type}`;
   return link ? (
     <a href={to} className={classes} {...attrs}>
       {children}
     </a>
   ) : (
-    <span className={classes} {...attrs}>
-      {children}
-    </span>
-  );
+      <span className={classes} {...attrs}>
+        {children}
+      </span>
+    );
 };
 Badge.defaultProps = {
   children: "No content",
@@ -40,6 +41,7 @@ Badge.defaultProps = {
   pill: false,
   round: false,
   to: "#",
-  type: ""
+  color: "grey-dark",
+  type: "badge--pagebuilder"
 };
 export default Badge;


### PR DESCRIPTION
Updated styles for badges: Badge types "primary" and "success" are being removed. Type is going to be "badge--pagebuilder", I left it as a default prop in case we want to pass a different style later on.
Badge is now accepting colours.
Styles "pill" and "round" are also being removed.