### PR TITLE
Bz2 xx/remove button warning

### DIFF
--- a/packages/More/__tests__/__snapshots__/More.test.tsx.snap
+++ b/packages/More/__tests__/__snapshots__/More.test.tsx.snap
@@ -29,17 +29,13 @@ exports[`More component should be defined and renders correctly (snapshot) 1`] =
           <withUtils()
             className="icon-button icon-button--round"
             disabled={false}
-            displayBg={false}
             onClick={[Function]}
-            toggled={false}
             type="button"
           >
             <Component
               className="icon-button icon-button--round"
               disabled={false}
-              displayBg={false}
               onClick={[Function]}
-              toggled={false}
               type="button"
               utils={
                 Object {
@@ -53,9 +49,7 @@ exports[`More component should be defined and renders correctly (snapshot) 1`] =
               <button
                 className="icon-button icon-button--round"
                 disabled={false}
-                displayBg={false}
                 onClick={[Function]}
-                toggled={false}
                 type="button"
               >
                 <span

--- a/packages/More/src/MoreAvatar/MoreAvatar.tsx
+++ b/packages/More/src/MoreAvatar/MoreAvatar.tsx
@@ -8,6 +8,8 @@ interface IMoreAvatarProps {
   isMoreMenu?: boolean;
   className?: string;
   children?: any;
+  toggled?: boolean;
+  displayBg?: boolean;
 }
 const MoreAvatar: React.SFC<IMoreAvatarProps> = ({
   children,
@@ -16,12 +18,14 @@ const MoreAvatar: React.SFC<IMoreAvatarProps> = ({
   isHeader,
   className,
   isMoreMenu,
+  toggled,
+  displayBg,
   ...props
 }) => {
   const buttonClassName = classnames({
     dropdown__button: isHeader,
     "icon-button icon-button--round": isMoreMenu,
-    [className as string]: Boolean(className)
+    [className as string]: Boolean(className),
   });
 
   return (
@@ -46,6 +50,6 @@ MoreAvatar.defaultProps = {
   className: "",
   isHeader: false,
   isMoreMenu: false,
-  label: ""
+  label: "",
 };
 export default MoreAvatar;

--- a/packages/More/src/MoreAvatar/MoreAvatar.tsx
+++ b/packages/More/src/MoreAvatar/MoreAvatar.tsx
@@ -27,6 +27,7 @@ const MoreAvatar: React.SFC<IMoreAvatarProps> = ({
     "icon-button icon-button--round": isMoreMenu,
     [className as string]: Boolean(className),
   });
+
   return (
     <Button onClick={handleToggle} className={buttonClassName} {...props}>
       {isHeader ? (

--- a/packages/More/src/MoreAvatar/MoreAvatar.tsx
+++ b/packages/More/src/MoreAvatar/MoreAvatar.tsx
@@ -27,7 +27,6 @@ const MoreAvatar: React.SFC<IMoreAvatarProps> = ({
     "icon-button icon-button--round": isMoreMenu,
     [className as string]: Boolean(className),
   });
-
   return (
     <Button onClick={handleToggle} className={buttonClassName} {...props}>
       {isHeader ? (


### PR DESCRIPTION
Destructure props (displayBg and toggled) that were being directly passed as attributes in button and were causing warnings in frontend.
![image](https://user-images.githubusercontent.com/46594025/80478583-00accb00-894e-11ea-823a-849377a218d7.png)
