### PR TITLE
Draft editor - add custom parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5203,6 +5203,11 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA=="
+    },
     "@types/draft-js": {
       "version": "0.10.34",
       "resolved": "https://registry.npmjs.org/@types/draft-js/-/draft-js-0.10.34.tgz",
@@ -10237,7 +10242,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
@@ -10246,8 +10250,7 @@
         "entities": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         }
       }
     },
@@ -10265,8 +10268,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -10281,7 +10283,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -10290,7 +10291,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -13074,6 +13074,16 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "html-dom-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-0.2.3.tgz",
+      "integrity": "sha512-GdzE63/U0IQEvcpAz0cUdYx2zQx0Ai+HWvE9TXEgwP27+SymUzKa7iB4DhjYpf2IdNLfTTOBuMS5nxeWOosSMQ==",
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "domhandler": "2.4.2",
+        "htmlparser2": "3.10.1"
+      }
+    },
     "html-element-map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
@@ -13142,6 +13152,17 @@
         }
       }
     },
+    "html-react-parser": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-0.10.5.tgz",
+      "integrity": "sha512-rtMWZ7KZjd9sO8jyIX7am0vGCIL45tCmctTnassT/BrTGeTaAZ4nQyqoGcx2v+vB8CAY+Q5PZiiV6eOiowq8dQ==",
+      "requires": {
+        "@types/domhandler": "2.4.1",
+        "html-dom-parser": "0.2.3",
+        "react-property": "1.0.1",
+        "style-to-object": "0.3.0"
+      }
+    },
     "html-to-draftjs": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.4.0.tgz",
@@ -13165,7 +13186,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -13178,14 +13198,12 @@
         "entities": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
         },
         "readable-stream": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -13592,6 +13610,11 @@
         "validate-npm-package-license": "^3.0.1",
         "validate-npm-package-name": "^3.0.0"
       }
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
       "version": "6.3.1",
@@ -18702,6 +18725,11 @@
         }
       }
     },
+    "react-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-1.0.1.tgz",
+      "integrity": "sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ=="
+    },
     "react-resize-detector": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-4.2.0.tgz",
@@ -20732,6 +20760,14 @@
       "requires": {
         "loader-utils": "^1.1.0",
         "schema-utils": "^1.0.0"
+      }
+    },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "stylis": {

--- a/packages/DraftEditor/__tests__/text-block-parser.test.tsx
+++ b/packages/DraftEditor/__tests__/text-block-parser.test.tsx
@@ -1,0 +1,25 @@
+import { mount } from "enzyme";
+import expect from "expect";
+import React from "react";
+import parseTextBlock from "../src/text-block-parser";
+
+describe("DraftEditor component", () => {
+  test("should be defined and parse text block value", () => {
+    const TextBlockPreview = ({
+      children,
+    }: {
+      children: JSX.Element | JSX.Element[];
+    }) => <>{children}</>;
+
+    const testValueJSON =
+      '{"blocks":[{"key":"ai4n8","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"4a0pe","text":"testing","type":"header-one","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"7mq4b","text":"HORIZONTAL_RULE","type":"atomic","depth":0,"inlineStyleRanges":[],"entityRanges":[{"offset":0,"length":15,"key":0}],"data":{}},{"key":"5mqhr","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}},{"key":"3dbt7","text":"","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{"0":{"type":"HORIZONTAL_RULE","mutability":"IMMUTABLE","data":{}}}}';
+
+    const textBlockContent = mount(
+      <TextBlockPreview>{parseTextBlock(testValueJSON)}</TextBlockPreview>
+    );
+
+    expect(textBlockContent).toBeDefined();
+    expect(textBlockContent.find("h1").text()).toContain("testing");
+    expect(textBlockContent.find("hr").length).toBe(1);
+  });
+});

--- a/packages/DraftEditor/package.json
+++ b/packages/DraftEditor/package.json
@@ -25,10 +25,8 @@
     "@blaze-react/text-area": "^0.5.0",
     "@blaze-react/utils": "^0.5.0",
     "@types/draft-js": "0.10.34",
-    "draft-js": "^0.11.0",
     "draft-js-alignment-plugin": "^2.0.6",
     "draft-js-drag-n-drop-plugin": "2.0.4",
-    "draft-js-export-html": "^1.4.1",
     "draft-js-focus-plugin": "3.0.1",
     "draft-js-image-plugin": "2.0.7",
     "draft-js-inline-toolbar-plugin": "^3.0.1",
@@ -38,7 +36,10 @@
     "draft-js-utils": "^1.4.0",
     "draftjs-to-html": "^0.8.4",
     "entities": "^2.0.0",
-    "html-to-draftjs": "^1.4.0"
+    "html-to-draftjs": "^1.4.0",
+    "draft-js": "^0.11.0",
+    "draft-js-export-html": "^1.4.1",
+    "html-react-parser": "^0.10.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/packages/DraftEditor/src/constants/index.tsx
+++ b/packages/DraftEditor/src/constants/index.tsx
@@ -15,6 +15,17 @@ const MARGINS = ["marginTop", "marginLeft", "marginRight", "marginBottom"];
 const BACKSPACE_COMMAND = "backspace";
 const HORIZONTAL_RULE = "HORIZONTAL_RULE";
 const HR = "HR";
+const CAMERA_CHAR_CODE = "d83d";
+const P_TAG = "p";
+const BR_TAG = "br";
+const ANCHOR_TAG = "a";
+const INPUT_TAG = "input";
+const FIGURE_TAG = "figure";
+const EMPTY_TAG = "empty";
+const CODE_BLOCK = "code-block";
+const SUBMIT = "submit";
+const HR_TAG = "<hr />";
+
 export {
   LINK,
   HANDLED,
@@ -33,4 +44,14 @@ export {
   BACKSPACE_COMMAND,
   HORIZONTAL_RULE,
   HR,
+  CAMERA_CHAR_CODE,
+  P_TAG,
+  BR_TAG,
+  ANCHOR_TAG,
+  INPUT_TAG,
+  FIGURE_TAG,
+  EMPTY_TAG,
+  CODE_BLOCK,
+  SUBMIT,
+  HR_TAG,
 };

--- a/packages/DraftEditor/src/index.tsx
+++ b/packages/DraftEditor/src/index.tsx
@@ -29,6 +29,7 @@ import { DraftPlugins, plugins } from "./DraftPlugins";
 import { CustomDraftPlugins } from "./DraftPlugins/CustomPlugins";
 import decorator from "./DraftPlugins/CustomPlugins/decorator";
 import { IDraftEditorProps } from "./interfaces";
+import parseTextBlock from "./text-block-parser";
 
 const DraftEditor: FunctionComponent<IDraftEditorProps> = ({
   utils: { classNames, ErrorMessage },
@@ -164,7 +165,11 @@ const DraftEditor: FunctionComponent<IDraftEditorProps> = ({
     );
     const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
     onEditorChange(
-      AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, " ")
+      AtomicBlockUtils.insertAtomicBlock(
+        editorState,
+        entityKey,
+        HORIZONTAL_RULE
+      )
     );
   };
 
@@ -239,3 +244,4 @@ DraftEditor.defaultProps = {
 };
 
 export default withUtils(DraftEditor);
+export { parseTextBlock };

--- a/packages/DraftEditor/src/interfaces/index.tsx
+++ b/packages/DraftEditor/src/interfaces/index.tsx
@@ -17,6 +17,7 @@ import {
 type DraftTextAlignment = "left" | "center" | "right";
 type SyntheticKeyboardEvent = React.KeyboardEvent<object>;
 type SyntheticEvent = React.SyntheticEvent<object>;
+type TComponent = (...arg: any) => JSX.Element;
 
 interface IImage {
   base64: string;
@@ -183,6 +184,12 @@ interface IPreviewIages {
   previewImages: IImage[];
 }
 
+interface IReactHtmlParserArgs {
+  attribs: any;
+  children: JSX.Element | any;
+  name: string;
+}
+
 export {
   IErrorMessage,
   DraftTextAlignment,
@@ -198,4 +205,6 @@ export {
   ILinkProps,
   IPreviewIages,
   IHTMLProps,
+  TComponent,
+  IReactHtmlParserArgs,
 };

--- a/packages/DraftEditor/src/text-block-parser/index.tsx
+++ b/packages/DraftEditor/src/text-block-parser/index.tsx
@@ -1,0 +1,85 @@
+import { convertFromRaw, EditorState, RawDraftContentState } from "draft-js";
+import { stateToHTML } from "draft-js-export-html";
+import parseHTML, { domToReact } from "html-react-parser";
+import React from "react";
+import {
+  ANCHOR_TAG,
+  BR_TAG,
+  FIGURE_TAG,
+  HORIZONTAL_RULE,
+  HR_TAG,
+  INPUT_TAG,
+  P_TAG,
+  SUBMIT,
+} from "../constants";
+import { IReactHtmlParserArgs, TComponent } from "../interfaces";
+import isValidJSON from "./is-valid-json";
+
+// tslint:disable-next-line: no-var-requires
+const entities = require("entities");
+
+function ReactHtmlParser(html: string, LinkWrapper?: TComponent) {
+  const options = {
+    replace: ({ attribs, children, name: tagName }: IReactHtmlParserArgs) => {
+      if (tagName === FIGURE_TAG) {
+        return <>{domToReact(children, options)}</>;
+      }
+      if (tagName === P_TAG) {
+        if (children && children.length === 1) {
+          const [child] = children;
+          const { name } = child;
+          if (name === BR_TAG) {
+            return <br />;
+          }
+        }
+      }
+      if (tagName === ANCHOR_TAG) {
+        return LinkWrapper ? (
+          <LinkWrapper {...attribs}>
+            {domToReact(children, options)}
+          </LinkWrapper>
+        ) : (
+          <a {...attribs}>{domToReact(children, options)}</a>
+        );
+      }
+      if (
+        tagName === INPUT_TAG &&
+        attribs.type !== SUBMIT &&
+        attribs.value === ""
+      ) {
+        return <input {...attribs} value={null} />;
+      }
+
+      return null;
+    },
+  };
+
+  return parseHTML(html, options);
+}
+
+function converEntityToHTML(
+  content: RawDraftContentState,
+  LinkWrapper?: TComponent
+) {
+  let HTML = entities.decodeHTML(
+    stateToHTML(
+      EditorState.createWithContent(convertFromRaw(content)).getCurrentContent()
+    )
+  );
+
+  HTML = HTML.replace(new RegExp(HORIZONTAL_RULE, "g"), HR_TAG);
+
+  return ReactHtmlParser(HTML, LinkWrapper);
+}
+
+function parseTextBlock(editor: any, LinkWrapper?: TComponent) {
+  const content = isValidJSON(editor);
+
+  if (!content) {
+    return [];
+  }
+
+  return converEntityToHTML(content, LinkWrapper);
+}
+
+export default parseTextBlock;

--- a/packages/DraftEditor/src/text-block-parser/index.tsx
+++ b/packages/DraftEditor/src/text-block-parser/index.tsx
@@ -57,7 +57,7 @@ function ReactHtmlParser(html: string, LinkWrapper?: TComponent) {
   return parseHTML(html, options);
 }
 
-function converEntityToHTML(
+function convertEntityToHTML(
   content: RawDraftContentState,
   LinkWrapper?: TComponent
 ) {
@@ -75,11 +75,7 @@ function converEntityToHTML(
 function parseTextBlock(editor: any, LinkWrapper?: TComponent) {
   const content = isValidJSON(editor);
 
-  if (!content) {
-    return [];
-  }
-
-  return converEntityToHTML(content, LinkWrapper);
+  return !content ? [] : convertEntityToHTML(content, LinkWrapper);
 }
 
 export default parseTextBlock;

--- a/packages/DraftEditor/src/text-block-parser/is-valid-json.tsx
+++ b/packages/DraftEditor/src/text-block-parser/is-valid-json.tsx
@@ -1,0 +1,9 @@
+function isValidJSON(candidate: any) {
+  try {
+    return JSON.parse(candidate);
+  } catch (e) {
+    return false;
+  }
+}
+
+export default isValidJSON;

--- a/packages/DraftEditor/stories/DraftEditor.stories.tsx
+++ b/packages/DraftEditor/stories/DraftEditor.stories.tsx
@@ -1,11 +1,8 @@
 import "@blaze-react/blaze-components-theme";
 import { storiesOf } from "@storybook/react";
-import { convertFromRaw, EditorState } from "draft-js";
-import { stateToHTML } from "draft-js-export-html";
 import React, { lazy, Suspense, useState } from "react";
 import DraftEditorReadme from "../README.md";
-
-const entities = require("entities");
+import { parseTextBlock } from "../src";
 
 storiesOf("DraftEditor", module)
   .addParameters({
@@ -21,7 +18,7 @@ storiesOf("DraftEditor", module)
 
       const onChange = ({
         event: {
-          target: { name, value },
+          target: { value },
         },
       }: {
         event: { target: { name: string; value: string } };
@@ -30,28 +27,11 @@ storiesOf("DraftEditor", module)
       };
 
       const preview = () => {
-        let convertStateToHTML: any = entities.decodeHTML(
-          stateToHTML(
-            EditorState.createWithContent(
-              convertFromRaw(JSON.parse(draftContent))
-            ).getCurrentContent()
-          )
-        );
-
-        const code =
-          convertStateToHTML.match(/<pre><code>(?:.*?)<\/code><\/pre>/g) || [];
-
-        code.forEach((htmlCode: string) => {
-          convertStateToHTML = convertStateToHTML.replace(
-            htmlCode,
-            entities.encode(htmlCode)
-          );
-        });
-
-        return convertStateToHTML;
+        return parseTextBlock(draftContent);
       };
 
       const DraftEditor: any = lazy(() => import("../src"));
+
       return (
         <Suspense fallback={<div>Loading...</div>}>
           <div className="component-wrapper">
@@ -67,7 +47,7 @@ storiesOf("DraftEditor", module)
               onChange={onChange}
             />
 
-            <div dangerouslySetInnerHTML={{ __html: preview() }} />
+            <div>{preview()}</div>
           </div>
         </Suspense>
       );


### PR DESCRIPTION
DraftEditor - Add custom parser
extend "draft-js-export-html" to handle unsupported tags and allow custom tag wrapper for links