### PR TITLE
BZ2-1688/sliders-performance 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18839,9 +18839,9 @@
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -120,7 +120,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
   setMaxValue(defaultMaxValue);
 
   function onStart(event: any) {
-    event.preventDefault();
+    event.defaultPrevented && event.preventDefault();
     const eventTouch = event.touches ? event.touches[0] : event;
 
     xAxis = this === touchLeft ? touchLeft.offsetLeft : touchRight.offsetLeft;
@@ -130,7 +130,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
     $(selector).addEventListener("mousemove", onMove);
     $(selector).addEventListener("mouseup", onStop);
-    $(selector).addEventListener("touchmove", onMove);
+    $(selector).addEventListener("touchmove", onMove, { passive: true });
     $(selector).addEventListener("touchend", onStop);
     document.addEventListener("click", onStop);
   }
@@ -223,8 +223,8 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   touchLeft.addEventListener("mousedown", onStart);
   touchRight.addEventListener("mousedown", onStart);
-  touchLeft.addEventListener("touchstart", onStart);
-  touchRight.addEventListener("touchstart", onStart);
+  touchLeft.addEventListener("touchstart", onStart, { passive: true });
+  touchRight.addEventListener("touchstart", onStart, { passive: true });
 };
 
 export default RangeFilter;

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -118,6 +118,25 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   setMinValue(defaultMinValue);
   setMaxValue(defaultMaxValue);
+  
+  const checkPassiveCompatibility = () => {
+    let passiveSupported = false;
+
+    try {
+      const options = {
+        get passive() {
+          passiveSupported = true;
+          return false;
+        }
+      };
+
+      window.addEventListener("checkOptions", null, options);
+      window.removeEventListener("checkOptions", null, options);
+      return passiveSupported;
+    } catch (err) {
+      passiveSupported = false;
+    }
+  }
 
   function onStart(event: any) {
     if (event.defaultPrevented) {
@@ -132,7 +151,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
     $(selector).addEventListener("mousemove", onMove);
     $(selector).addEventListener("mouseup", onStop);
-    $(selector).addEventListener("touchmove", onMove, { passive: true });
+    $(selector).addEventListener("touchmove", onMove, checkPassiveCompatibility ? { passive: true } : false)
     $(selector).addEventListener("touchend", onStop);
     document.addEventListener("click", onStop);
   }
@@ -225,8 +244,8 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   touchLeft.addEventListener("mousedown", onStart);
   touchRight.addEventListener("mousedown", onStart);
-  touchLeft.addEventListener("touchstart", onStart, { passive: true });
-  touchRight.addEventListener("touchstart", onStart, { passive: true });
+  touchLeft.addEventListener("touchstart", onStart, checkPassiveCompatibility ? { passive: true } : false)
+  touchRight.addEventListener("touchstart", onStart, checkPassiveCompatibility ? { passive: true } : false)
 };
 
 export default RangeFilter;

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -120,7 +120,9 @@ const RangeFilter = (selector: string, getMinMax: any) => {
   setMaxValue(defaultMaxValue);
 
   function onStart(event: any) {
-    event.defaultPrevented && event.preventDefault();
+    if (event.defaultPrevented) {
+      event.preventDefault()
+    };
     const eventTouch = event.touches ? event.touches[0] : event;
 
     xAxis = this === touchLeft ? touchLeft.offsetLeft : touchRight.offsetLeft;


### PR DESCRIPTION
[jira ticket](https://byte-9.atlassian.net/browse/BZ2-1688)

Added `passive { true }` to few `eventListeners` to avoid a warning.
Added the condition to `preventDefault` since adding the passive will throw the next error if keep de preventDefault.

  Docs: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md

**Before:**
warning fixed:
![Screenshot 2020-07-24 at 16 35 38](https://user-images.githubusercontent.com/43497439/88397874-3a666400-cdcd-11ea-83ab-579249df4279.png)

without the conditional `preventDefault`:
![Screenshot 2020-07-24 at 16 35 12](https://user-images.githubusercontent.com/43497439/88397870-39353700-cdcd-11ea-8eb9-79c7ec8f7f3f.png)

