### PR TITLE
Bz2 1688/sliders performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18839,9 +18839,9 @@
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/packages/RangeFilter/src/index.tsx
+++ b/packages/RangeFilter/src/index.tsx
@@ -59,15 +59,6 @@ const RangeFilter: FunctionComponent<IRangeFilterProps> = ({
     isContentLoaded(init, reInit);
   }, []);
 
-  useEffect(() => {
-    if (value) {
-      if (value.max !== inputs.max && value.min !== inputs.min) {
-        setInputs(value);
-        reInit();
-      }
-    }
-  }, [value]);
-
   const getMinMax = (minvalue: any, maxvalue: any) => {
     const newValue = { ...inputs, minValue: minvalue, maxValue: maxvalue };
     onChange({ value: newValue });

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -122,7 +122,9 @@ const RangeFilter = (selector: string, getMinMax: any) => {
   const checkPassiveCompatibility = () => {
     try {
       const opts = Object.defineProperty({}, 'passive', {
-        get: function () { }
+        get: () => {
+          return false
+        }
       });
       window.addEventListener("checkPassive", null, opts);
       window.removeEventListener("checkPassive", null, opts);
@@ -143,10 +145,9 @@ const RangeFilter = (selector: string, getMinMax: any) => {
     startX = eventTouch.pageX - xAxis;
     selectedTouch = this;
 
-    const isPassiveSupported = checkPassiveCompatibility();
     $(selector).addEventListener("mousemove", onMove);
     $(selector).addEventListener("mouseup", onStop);
-    $(selector).addEventListener("touchmove", onMove, isPassiveSupported ? { passive: true } : false)
+    $(selector).addEventListener("touchmove", onMove, checkPassiveCompatibility() ? { passive: true } : false)
     $(selector).addEventListener("touchend", onStop);
     document.addEventListener("click", onStop);
   }

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -120,7 +120,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
   setMaxValue(defaultMaxValue);
 
   function onStart(event: any) {
-    event.preventDefault();
+    event.defaultPrevented && event.preventDefault();
     const eventTouch = event.touches ? event.touches[0] : event;
 
     xAxis = this === touchLeft ? touchLeft.offsetLeft : touchRight.offsetLeft;
@@ -130,7 +130,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
     $(selector).addEventListener("mousemove", onMove);
     $(selector).addEventListener("mouseup", onStop);
-    $(selector).addEventListener("touchmove", onMove);
+    $(selector).addEventListener("touchmove", onMove, { passive: true });
     $(selector).addEventListener("touchend", onStop);
     document.addEventListener("click", onStop);
   }
@@ -223,8 +223,8 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   touchLeft.addEventListener("mousedown", onStart);
   touchRight.addEventListener("mousedown", onStart);
-  touchLeft.addEventListener("touchstart", onStart);
-  touchRight.addEventListener("touchstart", onStart);
+  touchLeft.addEventListener("touchstart", onStart, { passive: true });
+  touchRight.addEventListener("touchstart", onStart, { passive: true });
 };
 
 export default RangeFilter;

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -30,6 +30,21 @@ function $(selector: string) {
   return document.querySelector(`.${selector}`);
 }
 
+const checkPassiveCompatibility = () => {
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get: () => {
+        return false
+      }
+    });
+    window.addEventListener("checkPassive", null, opts);
+    window.removeEventListener("checkPassive", null, opts);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 const RangeFilter = (selector: string, getMinMax: any) => {
   let startX = 0;
   let xAxis = 0;
@@ -37,6 +52,8 @@ const RangeFilter = (selector: string, getMinMax: any) => {
   if (!$(selector)) {
     return;
   }
+
+  const isPassiveSupported = checkPassiveCompatibility();
 
   const { touchLeft, touchRight, lineSpan } = getElements($(selector));
 
@@ -119,20 +136,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
   setMinValue(defaultMinValue);
   setMaxValue(defaultMaxValue);
 
-  const checkPassiveCompatibility = () => {
-    try {
-      const opts = Object.defineProperty({}, 'passive', {
-        get: () => {
-          return false
-        }
-      });
-      window.addEventListener("checkPassive", null, opts);
-      window.removeEventListener("checkPassive", null, opts);
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
+
 
   function onStart(event: any) {
     if (event.defaultPrevented) {
@@ -147,7 +151,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
     $(selector).addEventListener("mousemove", onMove);
     $(selector).addEventListener("mouseup", onStop);
-    $(selector).addEventListener("touchmove", onMove, checkPassiveCompatibility() ? { passive: true } : false)
+    $(selector).addEventListener("touchmove", onMove, isPassiveSupported ? { passive: true } : false)
     $(selector).addEventListener("touchend", onStop);
     document.addEventListener("click", onStop);
   }
@@ -238,7 +242,6 @@ const RangeFilter = (selector: string, getMinMax: any) => {
     getMinMax(minValue, maxValue);
   };
 
-  const isPassiveSupported = checkPassiveCompatibility();
   touchLeft.addEventListener("mousedown", onStart);
   touchRight.addEventListener("mousedown", onStart);
   touchLeft.addEventListener("touchstart", onStart, isPassiveSupported ? { passive: true } : false)

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -118,23 +118,17 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   setMinValue(defaultMinValue);
   setMaxValue(defaultMaxValue);
-  
+
   const checkPassiveCompatibility = () => {
-    let passiveSupported = false;
-
     try {
-      const options = {
-        get passive() {
-          passiveSupported = true;
-          return false;
-        }
-      };
-
-      window.addEventListener("checkOptions", null, options);
-      window.removeEventListener("checkOptions", null, options);
-      return passiveSupported;
-    } catch (err) {
-      passiveSupported = false;
+      const opts = Object.defineProperty({}, 'passive', {
+        get: function () { }
+      });
+      window.addEventListener("checkPassive", null, opts);
+      window.removeEventListener("checkPassive", null, opts);
+      return true;
+    } catch (e) {
+      return false;
     }
   }
 
@@ -149,9 +143,10 @@ const RangeFilter = (selector: string, getMinMax: any) => {
     startX = eventTouch.pageX - xAxis;
     selectedTouch = this;
 
+    const isPassiveSupported = checkPassiveCompatibility();
     $(selector).addEventListener("mousemove", onMove);
     $(selector).addEventListener("mouseup", onStop);
-    $(selector).addEventListener("touchmove", onMove, checkPassiveCompatibility ? { passive: true } : false)
+    $(selector).addEventListener("touchmove", onMove, isPassiveSupported ? { passive: true } : false)
     $(selector).addEventListener("touchend", onStop);
     document.addEventListener("click", onStop);
   }
@@ -242,10 +237,11 @@ const RangeFilter = (selector: string, getMinMax: any) => {
     getMinMax(minValue, maxValue);
   };
 
+  const isPassiveSupported = checkPassiveCompatibility();
   touchLeft.addEventListener("mousedown", onStart);
   touchRight.addEventListener("mousedown", onStart);
-  touchLeft.addEventListener("touchstart", onStart, checkPassiveCompatibility ? { passive: true } : false)
-  touchRight.addEventListener("touchstart", onStart, checkPassiveCompatibility ? { passive: true } : false)
+  touchLeft.addEventListener("touchstart", onStart, isPassiveSupported ? { passive: true } : false)
+  touchRight.addEventListener("touchstart", onStart, isPassiveSupported ? { passive: true } : false)
 };
 
 export default RangeFilter;

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -118,6 +118,25 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   setMinValue(defaultMinValue);
   setMaxValue(defaultMaxValue);
+  
+  const checkPassiveCompatibility = () => {
+    let passiveSupported = false;
+
+    try {
+      const options = {
+        get passive() {
+          passiveSupported = true;
+          return false;
+        }
+      };
+
+      window.addEventListener("checkOptions", null, options);
+      window.removeEventListener("checkOptions", null, options);
+      return passiveSupported;
+    } catch (err) {
+      passiveSupported = false;
+    }
+  }
 
   function onStart(event: any) {
     if (event.defaultPrevented) {
@@ -132,7 +151,7 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
     $(selector).addEventListener("mousemove", onMove);
     $(selector).addEventListener("mouseup", onStop);
-    $(selector).addEventListener("touchmove", onMove, { passive: true });
+    $(selector).addEventListener("touchmove", onMove, checkPassiveCompatibility ? { passive: true } : false)
     $(selector).addEventListener("touchend", onStop);
     document.addEventListener("click", onStop);
   }
@@ -225,8 +244,8 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   touchLeft.addEventListener("mousedown", onStart);
   touchRight.addEventListener("mousedown", onStart);
-  touchLeft.addEventListener("touchstart", onStart, { passive: true });
-  touchRight.addEventListener("touchstart", onStart, { passive: true });
+  touchLeft.addEventListener("touchstart", onStart, checkPassiveCompatibility ? { passive: true } : false)
+  touchRight.addEventListener("touchstart", onStart, checkPassiveCompatibility ? { passive: true } : false)
 };
 
 export default RangeFilter;

--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -120,7 +120,9 @@ const RangeFilter = (selector: string, getMinMax: any) => {
   setMaxValue(defaultMaxValue);
 
   function onStart(event: any) {
-    event.defaultPrevented && event.preventDefault();
+    if (event.defaultPrevented) {
+      event.preventDefault()
+    };
     const eventTouch = event.touches ? event.touches[0] : event;
 
     xAxis = this === touchLeft ? touchLeft.offsetLeft : touchRight.offsetLeft;


### PR DESCRIPTION
[jira ticket](https://byte-9.atlassian.net/browse/BZ2-1688)

Added `passive { true }` to few `eventListeners` to avoid a warning.
Added the condition to `preventDefault` since adding the passive will throw the next error if keep de preventDefault.

  Docs: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md

**Before:**
warning fixed:
![Screenshot 2020-07-24 at 16 35 38](https://user-images.githubusercontent.com/43497439/88397874-3a666400-cdcd-11ea-83ab-579249df4279.png)

without the conditional `preventDefault`:
![Screenshot 2020-07-24 at 16 35 12](https://user-images.githubusercontent.com/43497439/88397870-39353700-cdcd-11ea-8eb9-79c7ec8f7f3f.png)