### PR TITLE
BZ2-1943 Remove onItemsRendered logic

### DIFF
--- a/packages/Multiselect/README.md
+++ b/packages/Multiselect/README.md
@@ -38,15 +38,25 @@ const data = {
 <Multiselect data={data} />;
 ```
 
+### onItemsRendered
+
+When the select options are scrolled if the onItemsRendered prop and isDynamic is false is set then this component will call it passing in the current start and stop indexes of the option items on display e.g.
+```js
+const onItemsRendered = ({ startIndex: 0, stopIndex: 20 }) => ...;
+```
+
 ## API
 
 ##### Multiselect can receive a number of `props` as follow:
 
-| NAME         |         TYPE          | DEFAULT  |
-| :----------- | :-------------------: | :------: |
-| data         |        Object         |    {}    |
-| limit        |        Number         |    0     |
-| placeholder  |        String         | 'Search' |
-| toggleButton |        String         |  empty   |
-| selected     |       Function        | () => {} |
-| children     | single/array of nodes |  empty   |
+| NAME              |         TYPE          | DEFAULT  |
+| :---------------: | :-------------------: | :------: |
+| data              |        Object         |    {}    |
+| limit             |        Number         |    0     |
+| placeholder       |        String         | 'Search' |
+| toggleButton      |        String         |  empty   |
+| selected          |       Function        | () => {} |
+| getSelected       |       Function        | () => {} |
+| onItemsRendered   |       Function        | () => {} |
+| isDynamic         |       Boolean         |  true    |
+| children          | single/array of nodes |  empty   |

--- a/packages/Multiselect/__tests__/Multiselect.test.tsx
+++ b/packages/Multiselect/__tests__/Multiselect.test.tsx
@@ -169,5 +169,28 @@ describe("Multiselect component", () => {
         },
       },
     })
-  })
+  });
+
+  it("should use onItemsRendered hook", async () => {
+    const onItemsRendered = jest.fn();
+    const length = 100;
+    const data = Array.from({ length }).map((_, index) => ({ id: index, name: `Name ${index}`, show: true }));
+    const override = {
+      data: {
+        data,
+        filterBy: ["name"],
+        identification: "id",
+        keyValue: "name",
+      },
+      isDynamic: true,
+      onItemsRendered
+    }
+
+    const { getByTestId, container } = render(<Multiselect name="test" {...override} />);
+    const input = getByTestId('input');
+    fireEvent.focus(input);
+    const [element] = container.querySelectorAll('.multiselect__dropdown')
+    fireEvent.scroll(element);
+    expect(onItemsRendered).toHaveBeenCalledWith({ startIndex: 0, stopIndex: 20 });
+  });
 });

--- a/packages/Multiselect/src/index.tsx
+++ b/packages/Multiselect/src/index.tsx
@@ -28,7 +28,6 @@ const MultiSelect: React.SFC<IMultiSelectProps> = ({
   const [limitReached, setLimitReached] = useState<boolean>(false);
   const [show, setShow] = useState<boolean>(false);
   const [searchValue, setSearchValue] = useState<string>("");
-  const [verifiedRanges, setVerifiedRanges] = useState<number[]>([]);
 
   const handleOutsideClick = (event: any) => {
     if (multiRef.current !== null && !multiRef.current.contains(event.target)) {
@@ -61,22 +60,10 @@ const MultiSelect: React.SFC<IMultiSelectProps> = ({
   }, [data]);
 
   const handleOnItemsRenderer = async (params: any) => {
-    if (!isDynamic) {
+    if (!isDynamic && !onItemsRendered) {
       return;
     }
-    const { startIndex, stopIndex } = params;
-    const rowsLength = dataCopy.length;
-    const loadIndex = Math.floor(rowsLength / 2);
-    if (
-      (loadIndex > 0 &&
-        loadIndex < startIndex &&
-        !verifiedRanges.includes(loadIndex)) ||
-      (stopIndex === rowsLength - 1 && startIndex === 0)
-    ) {
-      const response = await onItemsRendered({ ...params });
-      setVerifiedRanges([...verifiedRanges, loadIndex]);
-      setDataCopy(response.data);
-    }
+    return onItemsRendered(params);
   };
 
   const parseDataCopy = (value: string) => {

--- a/packages/Multiselect/src/index.tsx
+++ b/packages/Multiselect/src/index.tsx
@@ -60,10 +60,10 @@ const MultiSelect: React.SFC<IMultiSelectProps> = ({
   }, [data]);
 
   const handleOnItemsRenderer = async (params: any) => {
-    if (!isDynamic && !onItemsRendered) {
-      return;
+    if (isDynamic && onItemsRendered) {
+      return onItemsRendered(params);
     }
-    return onItemsRendered(params);
+    return;
   };
 
   const parseDataCopy = (value: string) => {


### PR DESCRIPTION
https://byte-9.atlassian.net/browse/BZ2-1943

Removes unused logic for onItemsRendered. If you know of anywhere that may use this logic mention in comments, but I've checked This repo and blaze and cant' see anything.

Work in progress as I had issues setting up repo on my local. The following needs looking at.
- tests need checking updating
- Any documentation needs updating