### PR TITLE
BZ2-2121 Make event consistent. Change time format to make 24 hour

### DIFF
--- a/packages/DateTimeInput/README.md
+++ b/packages/DateTimeInput/README.md
@@ -78,3 +78,10 @@ import "react-datepicker/dist/react-datepicker.css";
 | required          |           Boolean             |         false          |
 | error             |           Boolean             |         false          |
 | onChange          |           Function            |        () => {}        |
+
+
+## onChange events
+
+The raw onChange events are inconsistent from the underlying component and when using the today button so the component makes sure to set the the following props on an `event.target`
+- name: uses the component id prop
+- value: the date from the event

--- a/packages/DateTimeInput/__tests__/__snapshots__/DateTimeInput.test.tsx.snap
+++ b/packages/DateTimeInput/__tests__/__snapshots__/DateTimeInput.test.tsx.snap
@@ -59,6 +59,13 @@ exports[`DateTimeInput component should be defined and renders correctly type=da
         onSelect={[Function]}
         onYearChange={[Function]}
         open={false}
+        popperModifiers={
+          Object {
+            "flip": Object {
+              "enabled": false,
+            },
+          }
+        }
         preventOpenOnFocus={false}
         previousMonthButtonLabel="Previous Month"
         previousYearButtonLabel="Previous Year"
@@ -89,10 +96,8 @@ exports[`DateTimeInput component should be defined and renders correctly type=da
           popperComponent={null}
           popperModifiers={
             Object {
-              "preventOverflow": Object {
-                "boundariesElement": "viewport",
-                "enabled": true,
-                "escapeWithReference": true,
+              "flip": Object {
+                "enabled": false,
               },
             }
           }
@@ -207,7 +212,7 @@ exports[`DateTimeInput component should be defined and renders correctly type=da
         allowSameDay={false}
         customTimeInput={null}
         data-testid="date-time-input"
-        dateFormat="MMMM d, yyyy hh:mm"
+        dateFormat="MMMM d, yyyy HH:mm"
         dateFormatCalendar="LLLL yyyy"
         disabled={false}
         disabledKeyboardNavigation={false}
@@ -232,6 +237,13 @@ exports[`DateTimeInput component should be defined and renders correctly type=da
         onSelect={[Function]}
         onYearChange={[Function]}
         open={false}
+        popperModifiers={
+          Object {
+            "flip": Object {
+              "enabled": false,
+            },
+          }
+        }
         preventOpenOnFocus={false}
         previousMonthButtonLabel="Previous Month"
         previousYearButtonLabel="Previous Year"
@@ -262,10 +274,8 @@ exports[`DateTimeInput component should be defined and renders correctly type=da
           popperComponent={null}
           popperModifiers={
             Object {
-              "preventOverflow": Object {
-                "boundariesElement": "viewport",
-                "enabled": true,
-                "escapeWithReference": true,
+              "flip": Object {
+                "enabled": false,
               },
             }
           }
@@ -380,7 +390,7 @@ exports[`DateTimeInput component should be defined and renders correctly type=ti
         allowSameDay={false}
         customTimeInput={null}
         data-testid="date-time-input"
-        dateFormat="hh:mm"
+        dateFormat="HH:mm"
         dateFormatCalendar="LLLL yyyy"
         disabled={false}
         disabledKeyboardNavigation={false}
@@ -405,6 +415,13 @@ exports[`DateTimeInput component should be defined and renders correctly type=ti
         onSelect={[Function]}
         onYearChange={[Function]}
         open={false}
+        popperModifiers={
+          Object {
+            "flip": Object {
+              "enabled": false,
+            },
+          }
+        }
         preventOpenOnFocus={false}
         previousMonthButtonLabel="Previous Month"
         previousYearButtonLabel="Previous Year"
@@ -435,10 +452,8 @@ exports[`DateTimeInput component should be defined and renders correctly type=ti
           popperComponent={null}
           popperModifiers={
             Object {
-              "preventOverflow": Object {
-                "boundariesElement": "viewport",
-                "enabled": true,
-                "escapeWithReference": true,
+              "flip": Object {
+                "enabled": false,
               },
             }
           }
@@ -552,7 +567,7 @@ exports[`DateTimeInput component should be defined and renders correctly type=un
         allowSameDay={false}
         customTimeInput={null}
         data-testid="date-time-input"
-        dateFormat="MMMM d, yyyy hh:mm"
+        dateFormat="MMMM d, yyyy HH:mm"
         dateFormatCalendar="LLLL yyyy"
         disabled={false}
         disabledKeyboardNavigation={false}
@@ -577,6 +592,13 @@ exports[`DateTimeInput component should be defined and renders correctly type=un
         onSelect={[Function]}
         onYearChange={[Function]}
         open={false}
+        popperModifiers={
+          Object {
+            "flip": Object {
+              "enabled": false,
+            },
+          }
+        }
         preventOpenOnFocus={false}
         previousMonthButtonLabel="Previous Month"
         previousYearButtonLabel="Previous Year"
@@ -607,10 +629,8 @@ exports[`DateTimeInput component should be defined and renders correctly type=un
           popperComponent={null}
           popperModifiers={
             Object {
-              "preventOverflow": Object {
-                "boundariesElement": "viewport",
-                "enabled": true,
-                "escapeWithReference": true,
+              "flip": Object {
+                "enabled": false,
               },
             }
           }

--- a/packages/DateTimeInput/src/constants.tsx
+++ b/packages/DateTimeInput/src/constants.tsx
@@ -4,8 +4,8 @@ const TYPE_TIME = "time";
 
 const DATE_FORMAT_MAP = {
   [TYPE_DATE]: "MMMM d, yyyy",
-  [TYPE_DATE_TIME]: "MMMM d, yyyy hh:mm",
-  [TYPE_TIME]: "hh:mm",
+  [TYPE_DATE_TIME]: "MMMM d, yyyy HH:mm",
+  [TYPE_TIME]: "HH:mm",
 };
 
 export { TYPE_DATE, TYPE_DATE_TIME, TYPE_TIME, DATE_FORMAT_MAP };

--- a/packages/DateTimeInput/src/index.tsx
+++ b/packages/DateTimeInput/src/index.tsx
@@ -45,7 +45,7 @@ const DateTimeInput: FunctionComponent<IDateTimeInputProps> = ({
   type,
   validationMessage,
   value,
-  utils: { classNames, ErrorMessage },
+  utils: { classNames, ErrorMessage }
 }): JSX.Element => {
   const [newValue, setNewValue] = useState<Date | undefined>(value);
   const [newError, setError] = useState<boolean | undefined>(error);
@@ -66,14 +66,20 @@ const DateTimeInput: FunctionComponent<IDateTimeInputProps> = ({
 
   const handleChange = (
     date: Date,
-    event: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLDivElement, MouseEvent>,
+    event: any,
     forceClose: boolean = false
   ): void => {
     setNewValue(date);
     setOpen(!forceClose);
+
+    // make event consistent
+    const { target = {} } = event || {};
+    target.name = id;
+    target.value = date;
+
     // FIXME the native event is not always returned by react-datepicker
     // See https://byte-9.atlassian.net/browse/BZ2-2130
-    onChange({ event, value: date });
+    onChange({ event: { ...event, target }, value: date });
   };
 
   const requiredClassName: string = classNames({ required });
@@ -93,17 +99,24 @@ const DateTimeInput: FunctionComponent<IDateTimeInputProps> = ({
       <DatePicker
         data-testid="date-time-input"
         id={id}
+        name={id}
         onChange={handleChange}
         onFocus={() => setOpen(true)}
         showTimeInput={[TYPE_TIME, TYPE_DATE_TIME].includes(whitelistedType)}
         showTimeSelectOnly={whitelistedType === TYPE_TIME}
         onClickOutside={() => setOpen(false)}
+        popperModifiers={{
+          flip: {
+            enabled: false
+          }
+        }}
         dateFormat={DATE_FORMAT_MAP[whitelistedType]}
         open={newOpen}
         isClearable={true}
         selected={newValue}
         disabled={disabled}
         required={required}
+
       >
         {(whitelistedType === TYPE_DATE_TIME || whitelistedType === TYPE_DATE) && <div
           className="react-datepicker__today-button"
@@ -111,8 +124,8 @@ const DateTimeInput: FunctionComponent<IDateTimeInputProps> = ({
         >Today</div>}
       </DatePicker>
 
-      {newError && <ErrorMessage message={validationMessage} />}
-    </div>
+      { newError && <ErrorMessage message={validationMessage} />}
+    </div >
   );
 };
 
@@ -123,7 +136,7 @@ DateTimeInput.defaultProps = {
   modifier: "",
   required: false,
   type: TYPE_DATE_TIME,
-  validationMessage: "This field is required",
+  validationMessage: "This field is required"
 };
 
 export default withUtils(DateTimeInput);


### PR DESCRIPTION
https://byte-9.atlassian.net/browse/BZ2-2121

- There were issues in blaze with the pop up placement
- The on change event consistent and didn't set the target
- Updated time format to be 24 hours