### PR TITLE
fix: remove choose prompt when limit reached

### DIFF
--- a/packages/Multiselect/src/MultiSelect.tsx
+++ b/packages/Multiselect/src/MultiSelect.tsx
@@ -238,7 +238,7 @@ const MultiSelect: React.SFC<IMultiSelectProps> = ({
           getLabel={getLabel}
         />
 
-        {show && (
+        {show && !limitReached && (
           <MultiSelectList
             onItemsRendered={handleOnItemsRenderer}
             error={error}

--- a/packages/Multiselect/src/MultiSelectList.tsx
+++ b/packages/Multiselect/src/MultiSelectList.tsx
@@ -31,7 +31,7 @@ const MultiSelectList = ({
 
   return (
     <>
-      <div className="multiselect__dropdown">
+      {!limitReached ? <div className="multiselect__dropdown">
         {error && <ErrorMessage message={validationMessage} />}
 
         {!matchQuery.length && <p>{notFoundMessage}</p>}
@@ -68,8 +68,7 @@ const MultiSelectList = ({
             ></VirtualList>
           </div>
         )}
-      </div>
-      {limitReached && <p>{limitReachedMessage}</p>}
+      </div> : <p>{limitReachedMessage}</p>}
     </>
   );
 };


### PR DESCRIPTION
[Related task](https://byte-9.atlassian.net/browse/BZ2-3309)

-Update the select UI to remove the ‘choose’ prompt whenever the item limit is already reached.