### PR TITLE
feat: update fileupload component to allow setting credits

### DIFF
--- a/packages/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Accordion component should match snapshot 1`] = `
 <DocumentFragment>
   <div
     class="accordion"
+    data-testid="toggle-accordion"
   >
     <div
       class="accordion__header"
@@ -20,7 +21,6 @@ exports[`Accordion component should match snapshot 1`] = `
       </div>
       <div
         class="icon-button icon-button--accordion"
-        data-testid="toggle-accordion"
       >
         <i
           class="material-icons"
@@ -72,13 +72,13 @@ exports[`Accordion component should match snapshot 2`] = `
 <DocumentFragment>
   <div
     class="accordion"
+    data-testid="toggle-accordion"
   >
     <div
       class="accordion__header"
     >
       <div
         class="icon-button icon-button--accordion"
-        data-testid="toggle-accordion"
       >
         <i
           class="material-icons"

--- a/packages/FileUpload/__tests__/FileInputs/__snapshots__/FileInputs.test.tsx.snap
+++ b/packages/FileUpload/__tests__/FileInputs/__snapshots__/FileInputs.test.tsx.snap
@@ -41,6 +41,23 @@ exports[`FileInputs component should render without throwing error 1`] = `
   >
     <label
       class=""
+      for="0-credits-test-image-name"
+    >
+      image credits
+    </label>
+    <input
+      data-testid="input"
+      id="0-credits-test-image-name"
+      name="credits-0-test-image-name"
+      type="text"
+      value=""
+    />
+  </div>
+  <div
+    class="form-field form-field--input  "
+  >
+    <label
+      class=""
       for="0-altText-test-image-name"
     >
       Alternative text

--- a/packages/FileUpload/__tests__/FileList/__snapshots__/FileList.test.tsx.snap
+++ b/packages/FileUpload/__tests__/FileList/__snapshots__/FileList.test.tsx.snap
@@ -62,6 +62,23 @@ exports[`FileList component should match snapshot 1`] = `
         >
           <label
             class=""
+            for="0-credits-file-1png"
+          >
+            image credits
+          </label>
+          <input
+            data-testid="input"
+            id="0-credits-file-1png"
+            name="credits-0-file-1png"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="form-field form-field--input  "
+        >
+          <label
+            class=""
             for="0-altText-file-1png"
           >
             Alternative text

--- a/packages/FileUpload/src/FileInputs/index.tsx
+++ b/packages/FileUpload/src/FileInputs/index.tsx
@@ -41,7 +41,7 @@ const FileInputs = ({
     <Input
       label={getInputLabel(CREDITS, file.type)}
       onChange={handleInputChange}
-      value={data.caption}
+      value={data.credits}
       id={`${index}-credits-${sanitizedFilename(file)}`}
       name={`${CREDITS}-${index}-${sanitizedFilename(file)}`}
     />

--- a/packages/FileUpload/src/FileInputs/index.tsx
+++ b/packages/FileUpload/src/FileInputs/index.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { IMAGE, INPUT_TYPES, NAME } from '../constants';
 import { getInputLabel, sanitizedFilename } from '../utils';
 
-const { ALT_TEXT, CAPTION, HREF_URL, TITLE } = INPUT_TYPES;
+const { ALT_TEXT, CAPTION, HREF_URL, TITLE, CREDITS } = INPUT_TYPES;
 
 const FileInputs = ({
   data,
@@ -37,6 +37,13 @@ const FileInputs = ({
       value={data.caption}
       id={`${index}-caption-${sanitizedFilename(file)}`}
       name={`${CAPTION}-${index}-${sanitizedFilename(file)}`}
+    />
+    <Input
+      label={getInputLabel(CREDITS, file.type)}
+      onChange={handleInputChange}
+      value={data.caption}
+      id={`${index}-credits-${sanitizedFilename(file)}`}
+      name={`${CREDITS}-${index}-${sanitizedFilename(file)}`}
     />
     {file.type === IMAGE && (
       <>

--- a/packages/FileUpload/src/constants.tsx
+++ b/packages/FileUpload/src/constants.tsx
@@ -8,6 +8,7 @@ const INPUT_TYPES = {
   ALT_TEXT: "altText",
   CAPTION: "caption",
   TITLE: 'title',
+  CREDITS: 'credits',
   HREF_URL: 'hrefUrl'
 };
 


### PR DESCRIPTION
[Related task](https://byte-9.atlassian.net/browse/BZ2-3567)
Update the FileUpload component to allow setting of “credits” data. 

<img width="894" alt="Screenshot 2023-09-13 at 09 23 11" src="https://github.com/thebyte9/blaze-components-react/assets/53517873/2b801ce7-fa8b-44de-9711-660dbc8edb00">
