### PR TITLE
feat: add disabled prop

### DIFF
--- a/packages/Select/README.md
+++ b/packages/Select/README.md
@@ -86,5 +86,6 @@ const disabled = ["17006"]
 | keys             |  Array   |        []        |
 | onChange         | Function |     () => {}     |
 | disabled         |  Array   |        []        |
+| selectDisabled   |  Boolean |        false     |
 | showDefaultOption| Boolean  |       true       |
 | defaultTextValue |  String  | Please Choose... |

--- a/packages/Select/src/Select.tsx
+++ b/packages/Select/src/Select.tsx
@@ -13,6 +13,7 @@ interface ISelectProps {
   selected?: any;
   id?: string;
   disabled?: any[];
+  selectDisabled?: boolean;
   defaultTextValue?: string;
   showDefaultOption?: boolean;
 }
@@ -27,6 +28,7 @@ const Select: FunctionComponent<ISelectProps> = ({
   error,
   validationMessage,
   disabled,
+  selectDisabled,
   defaultTextValue,
   showDefaultOption,
   ...attrs
@@ -74,7 +76,7 @@ const Select: FunctionComponent<ISelectProps> = ({
       return setOption(option[value], option[text]);
     });
   };
-  
+
   return (
     <div className="form-field form-field--select">
       {label && (
@@ -82,7 +84,7 @@ const Select: FunctionComponent<ISelectProps> = ({
           {label}
         </label>
       )}
-      <select onChange={handleChange} disabled={!options.length} value={selectedOption} {...attrs}>
+      <select onChange={handleChange} disabled={selectDisabled || !options.length} value={selectedOption} {...attrs}>
         {(!required || showDefaultOption) && <option defaultValue="">{defaultTextValue}</option>}
         {renderOptions()}
       </select>
@@ -94,6 +96,7 @@ const Select: FunctionComponent<ISelectProps> = ({
 Select.defaultProps = {
   defaultTextValue: 'Please Choose...',
   disabled: [],
+  selectDisabled: false,
   error: false,
   keys: [],
   label: '',

--- a/packages/Select/stories/Select.stories.tsx
+++ b/packages/Select/stories/Select.stories.tsx
@@ -102,7 +102,10 @@ storiesOf("Select", module)
               <br />
 
               <h4>By default is disabled if none options</h4>
-              <Select label="Disabled" onChange={() => ({})} options={[]} />
+              <Select label="Disabled options" onChange={() => ({})} options={[]} />
+
+              <h4>Disabled select</h4>
+              <Select label="Disabled select" selectDisabled onChange={() => ({})} options={[]} />
             </div>
           </section>
         </div>


### PR DESCRIPTION
We already had the "disabled" prop, which was primarily used to deactivate certain select options. I considered renaming it to "disableOptions," but this change will be break change, so I opted to introduce a new prop with the name "selectDisabled."