### PR TITLE
fix: hide pagination if there is only one page

### DIFF
--- a/packages/Pagination/__tests__/Pagination.test.tsx
+++ b/packages/Pagination/__tests__/Pagination.test.tsx
@@ -20,6 +20,12 @@ describe('Pagination component', () => {
         expect(Pagination).toBeDefined();
     });
 
+    it('Should hide pagination if there is only one page', () => {
+        const { queryByTestId } = render(<Pagination {...defaultProps({ totalItems: 5 })} />);
+        const element = queryByTestId('pagination');
+        expect(element).not.toBeInTheDocument();
+    });
+
     it('should be defined and renders correctly (snapshot)', () => {
         const { container } = render(<Pagination {...defaultProps()} />);
         expect(container).toMatchSnapshot();

--- a/packages/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Pagination component should be defined and renders correctly (snapshot)
 <div>
   <div
     class="pagination"
+    data-testid="pagination"
   >
     <div
       class="pagination__rows"

--- a/packages/Pagination/src/Pagination.tsx
+++ b/packages/Pagination/src/Pagination.tsx
@@ -50,11 +50,13 @@ const Pagination: React.FC<PaginationProps> = (
     defaultItemsPerPage: itemsPerPage
   });
 
+  const pages = !totalItems ? null : calculatePages();
+
+  if (pages && pages.length === 1) return null;
+
   const getItemClassName = (number: number) =>
     `pagination__item ${number === page ? "pagination__item--active" : ""
     }`;
-
-  const pages = !totalItems ? null : calculatePages();
 
   const nextclassnames = buildClassNames('pagination__item pagination__item--icon', {
     ['pagination__item--disabled']: isNextDisabled,
@@ -65,7 +67,7 @@ const Pagination: React.FC<PaginationProps> = (
   });
 
   return (
-    <div className="pagination">
+    <div className="pagination" data-testid="pagination">
       {itemsPerPage && pages && <div className="pagination__rows" data-testid="items-perpage">
         <span> {options.displayText}</span>
         <Input

--- a/packages/Pagination/src/Pagination.tsx
+++ b/packages/Pagination/src/Pagination.tsx
@@ -52,7 +52,7 @@ const Pagination: React.FC<PaginationProps> = (
 
   const pages = !totalItems ? null : calculatePages();
 
-  if (pages && pages.length === 1) return null;
+  if (pages && pages.length <= 1) return null;
 
   const getItemClassName = (number: number) =>
     `pagination__item ${number === page ? "pagination__item--active" : ""


### PR DESCRIPTION
 Hide pagination if there is only one page