### PR TITLE
chore: button view export default

### DIFF
--- a/packages/Button/src/index.ts
+++ b/packages/Button/src/index.ts
@@ -3,3 +3,5 @@ import { ButtonView } from './view/ButtonView';
 import { DisplayIconProps } from './types';
 
 export { Button, ButtonView, DisplayIconProps };
+
+export default ButtonView;


### PR DESCRIPTION
Exports the ButtonView component as the default export, as follow up to the button aria label updates
https://github.com/thebyte9/blaze-components-react/pull/690
[Related story](https://byte-9.atlassian.net/browse/BZ2-3937)