### PR TITLE
chore: updates button props and snapshots

### DIFF
--- a/packages/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`Accordion component should match snapshot 1`] = `
       >
         <button
           class="button button--outline button--light button--rounded"
-          modifiers="outline,light,rounded"
           name="button"
           type="button"
         >
@@ -56,7 +55,6 @@ exports[`Accordion component should match snapshot 1`] = `
         </button>
         <button
           class="button button--rounded"
-          modifiers="rounded"
           name="button"
           type="button"
         >
@@ -106,7 +104,6 @@ exports[`Accordion component should match snapshot 2`] = `
       >
         <button
           class="button button--outline button--light button--rounded"
-          modifiers="outline,light,rounded"
           name="button"
           type="button"
         >
@@ -114,7 +111,6 @@ exports[`Accordion component should match snapshot 2`] = `
         </button>
         <button
           class="button button--rounded"
-          modifiers="rounded"
           name="button"
           type="button"
         >

--- a/packages/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`Button component should be defined and renders correctly (snapshot) 1`]
   <button
     aria-label="Test Button"
     class="button button--outline button--rounded"
-    modifiers="outline,rounded"
     type="button"
   />
 </DocumentFragment>

--- a/packages/Button/src/view/ButtonView.tsx
+++ b/packages/Button/src/view/ButtonView.tsx
@@ -2,38 +2,30 @@ import React from 'react';
 import { buildClassNames } from '@blaze-react/utils';
 import { IButtonViewProps } from '../types';
 
-export const ButtonView = ({ children, classes = '', label, ...rest }: IButtonViewProps): JSX.Element => {
-  const { modifiers = [], disabled, type = 'button' } = rest;
-
+export const ButtonView = ({
+  children,
+  classes = '',
+  label,
+  modifiers = [],
+  disabled,
+  type = 'button',
+  ...rest
+}: IButtonViewProps): JSX.Element => {
   const DeprecatedButton = () => {
-    console.warn('Modifiers will be deprecated in the near future. You should use CSS classes classes instead.');
-
     const formattedModifiers: string = modifiers.map((modifier) => `button--${modifier}`).join(' ');
     const buttonClassNames: string = buildClassNames('button', {
       [formattedModifiers]: !!modifiers,
     });
 
     return (
-      <button
-        disabled={disabled}
-        className={buttonClassNames}
-        type={type}
-        aria-label={label}
-        {...rest}
-      >
+      <button disabled={disabled} className={buttonClassNames} type={type} aria-label={label} {...rest}>
         {children}
       </button>
     );
   };
 
   const BlazeButton = (
-    <button
-      type="button"
-      className={classes}
-      disabled={disabled}
-      aria-label={label}
-      {...rest}
-    >
+    <button type="button" className={classes} disabled={disabled} aria-label={label} {...rest}>
       {children}
     </button>
   );

--- a/packages/ButtonSelect/__tests__/__snapshots__/ButtonSelect.test.tsx.snap
+++ b/packages/ButtonSelect/__tests__/__snapshots__/ButtonSelect.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`ButtonSelect component should be defined and renders correctly (snapsho
     <button
       class="button button--full-width"
       data-testid="button-select-toggle"
-      modifiers="full-width"
       type="button"
     >
       <i
@@ -30,7 +29,6 @@ exports[`ButtonSelect component should toggle 1`] = `
     <button
       class="button button--full-width"
       data-testid="button-select-toggle"
-      modifiers="full-width"
       type="button"
     >
       <i

--- a/packages/Modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/packages/Modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -114,14 +114,12 @@ exports[`Modal component should render and close alert modal 1`] = `
       >
         <button
           class="button button--cancel"
-          modifiers="cancel"
           type="button"
         >
           Cancel
         </button>
         <button
           class="button button--alert button--small"
-          modifiers="alert,small"
           type="button"
         >
           delete


### PR DESCRIPTION
Refactors the ButtonView component to directly destructure the modifiers, disabled, and type props from the component's parameters instead of from the rest object. This improves code readability.
[related task](https://byte-9.atlassian.net/browse/BZ2-3937)