### PR TITLE
chore: removes spaces in labels and do not call window when undefined

### DIFF
--- a/packages/Autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/Autocomplete/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -11,9 +11,7 @@ exports[`Autocomplete component should match snapshot 1`] = `
       <label
         class=""
         for="input-text"
-      >
-         
-      </label>
+      />
       <input
         data-testid="input"
         id="input-text"

--- a/packages/Blaze-ui/src/module/_forms.scss
+++ b/packages/Blaze-ui/src/module/_forms.scss
@@ -78,6 +78,10 @@ label {
   &:empty {
     display: none;
   }
+
+  > span {
+    margin-left: 5px;
+  }
 }
 
 input[type][disabled] {

--- a/packages/Blaze-ui/src/module/_tooltip.scss
+++ b/packages/Blaze-ui/src/module/_tooltip.scss
@@ -126,6 +126,10 @@
   }
 }
 
+.tooltip-buffer {
+  margin: 50px !important;
+}
+
 .demo {
   display: flex;
   flex-direction: column;

--- a/packages/Blaze-ui/src/module/_tooltip.scss
+++ b/packages/Blaze-ui/src/module/_tooltip.scss
@@ -8,15 +8,6 @@
   color: $black;
   padding-right: 20px;
 
-  // &::before {
-  //   content: '';
-  //   top: 100%;
-  //   width: 100%;
-  //   height: 50px;
-  //   background-color: transparent;
-  //   z-index: -10;
-  // }
-
   .tooltip-close-icon {
     cursor: pointer;
     position: absolute;
@@ -124,10 +115,6 @@
   &.is-disabled {
     cursor: initial;
   }
-}
-
-.tooltip-buffer {
-  margin: 50px !important;
 }
 
 .demo {

--- a/packages/Blaze-ui/src/module/_tooltip.scss
+++ b/packages/Blaze-ui/src/module/_tooltip.scss
@@ -8,6 +8,15 @@
   color: $black;
   padding-right: 20px;
 
+  // &::before {
+  //   content: '';
+  //   top: 100%;
+  //   width: 100%;
+  //   height: 50px;
+  //   background-color: transparent;
+  //   z-index: -10;
+  // }
+
   .tooltip-close-icon {
     cursor: pointer;
     position: absolute;

--- a/packages/Checkboxes/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/Checkboxes/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Checkboxes component should be defined and renders correctly (snapshot)
         for="1-checkbox-checkbox"
       >
         <span>
-          first 
+          first
         </span>
       </label>
     </div>
@@ -48,7 +48,7 @@ exports[`Checkboxes component should be defined and renders correctly (snapshot)
         for="2-checkbox-checkbox"
       >
         <span>
-          I accept 
+          I accept
         </span>
       </label>
     </div>
@@ -74,7 +74,7 @@ exports[`Checkboxes component should be defined and renders correctly (snapshot)
         for="3-checkbox-checkbox"
       >
         <span>
-          Disabled 
+          Disabled
         </span>
       </label>
     </div>
@@ -104,7 +104,7 @@ exports[`Checkboxes component should render a disabled checkbox 1`] = `
         for="1-checkbox-checkbox"
       >
         <span>
-          first 
+          first
         </span>
       </label>
     </div>
@@ -130,7 +130,7 @@ exports[`Checkboxes component should render a disabled checkbox 1`] = `
         for="2-checkbox-checkbox"
       >
         <span>
-          I accept 
+          I accept
         </span>
       </label>
     </div>
@@ -156,7 +156,7 @@ exports[`Checkboxes component should render a disabled checkbox 1`] = `
         for="3-checkbox-checkbox"
       >
         <span>
-          Disabled 
+          Disabled
         </span>
       </label>
     </div>

--- a/packages/Checkboxes/src/Checkboxes.tsx
+++ b/packages/Checkboxes/src/Checkboxes.tsx
@@ -104,7 +104,7 @@ const CheckBoxes: FunctionComponent<ICheckBoxesProps> = ({
               data-testid={id}
               label={
                 <>
-                  {label} <Tooltip {...tooltip} />
+                  {label}<Tooltip {...tooltip} />
                 </>
               }
               name={checkboxName}

--- a/packages/DateRange/__tests__/__snapshots__/DateRange.test.tsx.snap
+++ b/packages/DateRange/__tests__/__snapshots__/DateRange.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`DateRange component should be defined and renders correctly (snapshot) 
       class=""
       for="select-undefined"
     >
-      Date Range 
+      Date Range
     </label>
     <select
       data-testid="select-date-range"
@@ -78,9 +78,7 @@ exports[`DateRange component should be defined and renders correctly (snapshot) 
         <label
           class=""
           for="input-text"
-        >
-           
-        </label>
+        />
         <input
           class="range-date"
           data-testid="From"
@@ -110,9 +108,7 @@ exports[`DateRange component should be defined and renders correctly (snapshot) 
         <label
           class=""
           for="input-text"
-        >
-           
-        </label>
+        />
         <input
           class="range-date"
           data-testid="To"

--- a/packages/DateRange/__tests__/__snapshots__/DateRangeSelectDay.test.tsx.snap
+++ b/packages/DateRange/__tests__/__snapshots__/DateRangeSelectDay.test.tsx.snap
@@ -20,9 +20,7 @@ exports[`DateRange component should be defined and renders correctly (snapshot) 
         <label
           class=""
           for="input-text"
-        >
-           
-        </label>
+        />
         <input
           class="range-date"
           data-testid="custom"

--- a/packages/DateTimeInput/__tests__/__snapshots__/DateTimeInput.test.tsx.snap
+++ b/packages/DateTimeInput/__tests__/__snapshots__/DateTimeInput.test.tsx.snap
@@ -7,9 +7,7 @@ exports[`DateTimeInput component should be defined and renders correctly type=da
   >
     <label
       class=""
-    >
-       
-    </label>
+    />
     <div
       class="react-datepicker-wrapper"
     >
@@ -44,9 +42,7 @@ exports[`DateTimeInput component should be defined and renders correctly type=da
   >
     <label
       class=""
-    >
-       
-    </label>
+    />
     <div
       class="react-datepicker-wrapper"
     >
@@ -81,9 +77,7 @@ exports[`DateTimeInput component should be defined and renders correctly type=ti
   >
     <label
       class=""
-    >
-       
-    </label>
+    />
     <div
       class="react-datepicker-wrapper"
     >
@@ -118,9 +112,7 @@ exports[`DateTimeInput component should be defined and renders correctly type=un
   >
     <label
       class=""
-    >
-       
-    </label>
+    />
     <div
       class="react-datepicker-wrapper"
     >

--- a/packages/DateTimeInput/src/DateTimeInput.tsx
+++ b/packages/DateTimeInput/src/DateTimeInput.tsx
@@ -94,7 +94,7 @@ const DateTimeInput: FunctionComponent<IDateTimeInputProps> = ({
     <div className={rootClasses} ref={containerRef}>
 
       <label htmlFor={id} className={requiredClassName}>
-        {label} <Tooltip {...tooltip} />
+        {label}<Tooltip {...tooltip} />
       </label>
 
       <DatePicker

--- a/packages/FileUpload/__tests__/FileInputs/__snapshots__/FileInputs.test.tsx.snap
+++ b/packages/FileUpload/__tests__/FileInputs/__snapshots__/FileInputs.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`FileInputs component should render without throwing error 1`] = `
         </svg>
          
       </span>
-       
     </label>
     <input
       data-testid="input"
@@ -76,7 +75,6 @@ exports[`FileInputs component should render without throwing error 1`] = `
         </svg>
          
       </span>
-       
     </label>
     <input
       data-testid="input"
@@ -118,7 +116,6 @@ exports[`FileInputs component should render without throwing error 1`] = `
         </svg>
          
       </span>
-       
     </label>
     <input
       data-testid="input"
@@ -160,7 +157,6 @@ exports[`FileInputs component should render without throwing error 1`] = `
         </svg>
          
       </span>
-       
     </label>
     <input
       data-testid="input"
@@ -202,7 +198,6 @@ exports[`FileInputs component should render without throwing error 1`] = `
         </svg>
          
       </span>
-       
     </label>
     <input
       data-testid="input"
@@ -244,7 +239,6 @@ exports[`FileInputs component should render without throwing error 1`] = `
         </svg>
          
       </span>
-       
     </label>
     <select
       data-testid="store-type"

--- a/packages/FileUpload/__tests__/FileList/__snapshots__/FileList.test.tsx.snap
+++ b/packages/FileUpload/__tests__/FileList/__snapshots__/FileList.test.tsx.snap
@@ -55,7 +55,6 @@ exports[`FileList component should match snapshot 1`] = `
               </svg>
                
             </span>
-             
           </label>
           <input
             data-testid="input"
@@ -97,7 +96,6 @@ exports[`FileList component should match snapshot 1`] = `
               </svg>
                
             </span>
-             
           </label>
           <input
             data-testid="input"
@@ -139,7 +137,6 @@ exports[`FileList component should match snapshot 1`] = `
               </svg>
                
             </span>
-             
           </label>
           <input
             data-testid="input"
@@ -181,7 +178,6 @@ exports[`FileList component should match snapshot 1`] = `
               </svg>
                
             </span>
-             
           </label>
           <input
             data-testid="input"
@@ -223,7 +219,6 @@ exports[`FileList component should match snapshot 1`] = `
               </svg>
                
             </span>
-             
           </label>
           <input
             data-testid="input"
@@ -265,7 +260,6 @@ exports[`FileList component should match snapshot 1`] = `
               </svg>
                
             </span>
-             
           </label>
           <select
             data-testid="store-type"

--- a/packages/Input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/packages/Input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -8,9 +8,7 @@ exports[`Input component should be defined and renders correctly (snapshot) 1`] 
     <label
       class=""
       for="input-text"
-    >
-       
-    </label>
+    />
     <input
       data-testid="input"
       id="input-text"

--- a/packages/Input/src/deprecated/Input.tsx
+++ b/packages/Input/src/deprecated/Input.tsx
@@ -82,7 +82,7 @@ const Input: FunctionComponent<IInputProps> = ({
   return (
     <div className={`form-field form-field--input ${modifierClassName} ${passwordClassName}`}>
       <label htmlFor={fieldName} className={requiredClassName}>
-        {label} <Tooltip {...tooltip} />
+        {label}<Tooltip {...tooltip} />
       </label>
       <input
         data-testid="input"

--- a/packages/Multiselect/__tests__/__snapshots__/Multiselect.test.tsx.snap
+++ b/packages/Multiselect/__tests__/__snapshots__/Multiselect.test.tsx.snap
@@ -72,7 +72,6 @@ exports[`Multiselect component should be defined and renders correctly (snapshot
               for="input-text"
             >
               
-               
             </label>
             <input
               data-testid="input"
@@ -161,7 +160,6 @@ exports[`Multiselect component should be defined and renders correctly when is o
               for="input-text"
             >
               
-               
             </label>
             <input
               data-testid="input"

--- a/packages/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`Pagination component should be defined and renders correctly (snapshot)
           for="input-number"
         >
           
-           
         </label>
         <input
           class="pagination__input"

--- a/packages/RadioButton/__tests__/__snapshots__/RadioButton.test.tsx.snap
+++ b/packages/RadioButton/__tests__/__snapshots__/RadioButton.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`RadioButton component should be defined xand renders correctly (snapsho
     <label
       for="one"
     >
-      Example 
+      Example
     </label>
   </div>
   <div
@@ -36,7 +36,7 @@ exports[`RadioButton component should be defined xand renders correctly (snapsho
     <label
       for="two"
     >
-      I accept 
+      I accept
     </label>
   </div>
   <div
@@ -54,7 +54,7 @@ exports[`RadioButton component should be defined xand renders correctly (snapsho
     <label
       for="three"
     >
-      Disabled 
+      Disabled
     </label>
   </div>
 </DocumentFragment>

--- a/packages/RadioButton/src/RadioButton.tsx
+++ b/packages/RadioButton/src/RadioButton.tsx
@@ -68,7 +68,7 @@ const RadioButton: React.SFC<IRadioButtonProps> = ({
               {...attrs}
             />
             <label htmlFor={id}>
-              {label} <Tooltip {...tooltip} />
+              {label}<Tooltip {...tooltip} />
             </label>
           </div>
         );

--- a/packages/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Select component should be disabled when none options 1`] = `
       class="required"
       for="select-undefined"
     >
-      Select label 
+      Select label
     </label>
     <select
       disabled=""

--- a/packages/Select/src/Select.tsx
+++ b/packages/Select/src/Select.tsx
@@ -88,7 +88,7 @@ const Select: FunctionComponent<ISelectProps> = ({
     <div className="form-field form-field--select">
       {label && (
         <label htmlFor={fieldName} className={requiredClassName}>
-          {label} <Tooltip {...tooltip} />
+          {label}<Tooltip {...tooltip} />
         </label>
       )}
       <select

--- a/packages/Table/__tests__/src/TableBody/__snapshots__/TableBody.test.tsx.snap
+++ b/packages/Table/__tests__/src/TableBody/__snapshots__/TableBody.test.tsx.snap
@@ -33,9 +33,7 @@ exports[`Table body should render data and pass it throught virtual list 1`] = `
             <label
               for="1-checkbox"
             >
-              <span>
-                 
-              </span>
+              <span />
             </label>
           </div>
         </div>
@@ -96,9 +94,7 @@ exports[`Table body should render data and pass it throught virtual list 1`] = `
             <label
               for="2-checkbox"
             >
-              <span>
-                 
-              </span>
+              <span />
             </label>
           </div>
         </div>

--- a/packages/Textarea/src/TextArea.tsx
+++ b/packages/Textarea/src/TextArea.tsx
@@ -42,7 +42,7 @@ const Textarea: FunctionComponent<ITextareaProps> = ({
     <div className="form-field form-field--textarea">
       {label && (
         <label htmlFor={fieldName} className={requiredClassName}>
-          {label} <Tooltip {...tooltip} />
+          {label}<Tooltip {...tooltip} />
         </label>
       )}
       <textarea

--- a/packages/Tooltip/src/Tooltip.tsx
+++ b/packages/Tooltip/src/Tooltip.tsx
@@ -168,38 +168,33 @@ const Tooltip: React.FC<TooltipProps> = ({
         {show && tooltipContent
           ? ReactDOM.createPortal(
             <span
-              className="tooltip-buffer"
+              ref={tooltipMessage}
+              className={`tooltip-message ${className} on-${newPosition.current} ${isDisplayTooltipIndicator ? 'is-indicator' : ''}`}
+              style={{
+                color,
+                '--background-color': backgroundColor,
+                ...customPosition,
+                visibility: (newPosition.current === availableTooltipPositions.left ||
+                  newPosition.current === availableTooltipPositions.top) && !isTooltipVisible
+                  ? 'hidden'
+                  : 'visible',
+                ...styles,
+              }}
+              onMouseEnter={showTooltip}
+              onMouseLeave={isHoverTrigger && !disabled && !isHasTouch ? hideTooltip : undefined}
             >
-              <span
-                ref={tooltipMessage}
-                className={`tooltip-message ${className} on-${newPosition.current} ${isDisplayTooltipIndicator ? 'is-indicator' : ''}`}
-                style={{
-                  color,
-                  '--background-color': backgroundColor,
-                  ...customPosition,
-                  visibility: (newPosition.current === availableTooltipPositions.left ||
-                    newPosition.current === availableTooltipPositions.top) && !isTooltipVisible
-                    ? 'hidden'
-                    : 'visible',
-                  ...styles,
-                }}
-                onMouseEnter={showTooltip}
-                onMouseLeave={isHoverTrigger && !disabled && !isHasTouch ? hideTooltip : undefined}
-              >
-                {isClickTrigger && (
-                  <i
-                    className="fa fa-times"
-                    aria-hidden="true"
-                    onClick={hideTooltip}
-                  ></i>
-                )}
-                {typeof tooltipContent === 'string' ? parseHTML(tooltipContent) : tooltipContent}
-              </span>
+              {isClickTrigger && (
+                <i
+                  className="fa fa-times"
+                  aria-hidden="true"
+                  onClick={hideTooltip}
+                ></i>
+              )}
+              {typeof tooltipContent === 'string' ? parseHTML(tooltipContent) : tooltipContent}
             </span>,
             target
           )
           : null}
-
         {children ? children : <i className="material-icons">info_outline</i>}
       </span>
     </ConditionalWrapper>

--- a/packages/Tooltip/src/Tooltip.tsx
+++ b/packages/Tooltip/src/Tooltip.tsx
@@ -168,33 +168,38 @@ const Tooltip: React.FC<TooltipProps> = ({
         {show && tooltipContent
           ? ReactDOM.createPortal(
             <span
-              ref={tooltipMessage}
-              className={`tooltip-message ${className} on-${newPosition.current} ${isDisplayTooltipIndicator ? 'is-indicator' : ''}`}
-              style={{
-                color,
-                '--background-color': backgroundColor,
-                ...customPosition,
-                visibility: (newPosition.current === availableTooltipPositions.left ||
-                  newPosition.current === availableTooltipPositions.top) && !isTooltipVisible
-                  ? 'hidden'
-                  : 'visible',
-                ...styles,
-              }}
-              onMouseEnter={showTooltip}
-              onMouseLeave={isHoverTrigger && !disabled && !isHasTouch ? hideTooltip : undefined}
+              className="tooltip-buffer"
             >
-              {isClickTrigger && (
-                <i
-                  className="fa fa-times"
-                  aria-hidden="true"
-                  onClick={hideTooltip}
-                ></i>
-              )}
-              {typeof tooltipContent === 'string' ? parseHTML(tooltipContent) : tooltipContent}
+              <span
+                ref={tooltipMessage}
+                className={`tooltip-message ${className} on-${newPosition.current} ${isDisplayTooltipIndicator ? 'is-indicator' : ''}`}
+                style={{
+                  color,
+                  '--background-color': backgroundColor,
+                  ...customPosition,
+                  visibility: (newPosition.current === availableTooltipPositions.left ||
+                    newPosition.current === availableTooltipPositions.top) && !isTooltipVisible
+                    ? 'hidden'
+                    : 'visible',
+                  ...styles,
+                }}
+                onMouseEnter={showTooltip}
+                onMouseLeave={isHoverTrigger && !disabled && !isHasTouch ? hideTooltip : undefined}
+              >
+                {isClickTrigger && (
+                  <i
+                    className="fa fa-times"
+                    aria-hidden="true"
+                    onClick={hideTooltip}
+                  ></i>
+                )}
+                {typeof tooltipContent === 'string' ? parseHTML(tooltipContent) : tooltipContent}
+              </span>
             </span>,
             target
           )
           : null}
+
         {children ? children : <i className="material-icons">info_outline</i>}
       </span>
     </ConditionalWrapper>

--- a/packages/Tooltip/src/hooks/useTooltipStyles.ts
+++ b/packages/Tooltip/src/hooks/useTooltipStyles.ts
@@ -10,7 +10,7 @@ const useTooltipStyles = (
   childrenWidth: number | undefined,
   childrenHeight: number | undefined,
   isParentFixed: boolean | undefined,
-  wrapperParentUpdated: { top: number; left: number }
+  wrapperParentUpdated: { top: number; left: number },
 ): any => {
   const getStylesList = useCallback(() => {
     if (!tooltipWrapperRef.current) {
@@ -25,6 +25,10 @@ const useTooltipStyles = (
       tooltipDOMUtils.getElementOffset(tooltipWrapperRef.current).top + wrapperRect.height / 2;
 
     const getNewPosition = (pos: string) => {
+      if (typeof window === 'undefined') {
+        return pos;
+      }
+
       const positionChecks = {
         [availableTooltipPositions.top]: wrapperRect.top < (childrenHeight || 0) + space,
         [availableTooltipPositions.right]: wrapperRect.right + ((childrenWidth || 0) + space * 1.5) > window.innerWidth,
@@ -42,7 +46,8 @@ const useTooltipStyles = (
           }[key];
         }
       }
-      return pos; 
+
+      return pos;
     };
 
     const pos = getNewPosition(position);
@@ -53,7 +58,7 @@ const useTooltipStyles = (
           space,
           tooltipDOMUtils.getElementOffset(tooltipWrapperRef.current).top -
             (childrenHeight || 0) -
-            (isDisplayTooltipIndicator ? space : space / 2)
+            (isDisplayTooltipIndicator ? space : space / 2),
         );
         style.left = centeredHorizontalPosition;
       },

--- a/packages/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/Tooltip/stories/Tooltip.stories.tsx
@@ -28,7 +28,7 @@ storiesOf('Tooltip', module)
         <div className="demo">
           <p>
             Tooltip on{' '}
-            <Tooltip  tooltipContent={<>tooltip on <em>Es un hecho establecido hace demasiado tiempo que un lector se distraerá con el contenido del texto de un sitio mientras que mira su diseño. El punto de usar Lorem Ipsum es que tiene una distribución más o menos normal de las letras, al contrario de usar textos como por ejemplo </em></>}>
+            <Tooltip tooltipContent={<>tooltip on <em>top</em></>}>
               <span className="underline">top</span>
             </Tooltip>
           </p>

--- a/packages/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/Tooltip/stories/Tooltip.stories.tsx
@@ -28,7 +28,7 @@ storiesOf('Tooltip', module)
         <div className="demo">
           <p>
             Tooltip on{' '}
-            <Tooltip tooltipContent={<>tooltip on <em>top</em></>}>
+            <Tooltip  tooltipContent={<>tooltip on <em>Es un hecho establecido hace demasiado tiempo que un lector se distraerá con el contenido del texto de un sitio mientras que mira su diseño. El punto de usar Lorem Ipsum es que tiene una distribución más o menos normal de las letras, al contrario de usar textos como por ejemplo </em></>}>
               <span className="underline">top</span>
             </Tooltip>
           </p>


### PR DESCRIPTION
### Checklist

- [x] Update title using conventional commits syntax
- [x] Add URL to ticket
- [x] Add appropriate label
- [ ] Add description explaining changes
- [ ] Add acceptance critiera
- [ ] (optional) Add screenshots / screen recordings
- [ ] (optional) Add testing instructions
- [ ] (optional) Add release instructions
- [ ] (optional) Add documentation in README.md file
- [ ] Add unit tests to ensure consistent code coverage
- [ ] Perform self-review of code changes
- [ ] Check Sonarcloud result
- [ ] Check whether unit tests are passing
- [ ] Add reviewers and notify them on Slack
- [ ] Update ticket status
- [ ] (optional) Delete branch after merge

## Ticket

[Ticket](https://byte-9.atlassian.net/browse/BZ2-4030?focusedCommentId=33678)

## Description

-Fix window error on server side render : Do not do any calls to window when window is undefined

-Remove spaces in labels where tooltips are used: e.g. <label>{label}<Tooltip

-Add styles for tooltip inside a label to have left margin to move away from the label text


## Acceptance critiera

n/a

## Screenshots / screen recordings
<img width="679" alt="Screenshot 2024-11-19 at 12 57 36" src="https://github.com/user-attachments/assets/27269a98-af98-4131-9fd7-2cdf7ea13544">



## Testing instructions

n/a

## Release instructions

n/a
