### PR TITLE
fix: move tooltip on switches to end of label

### DIFF
--- a/packages/Blaze-ui/src/module/_switches.scss
+++ b/packages/Blaze-ui/src/module/_switches.scss
@@ -4,7 +4,7 @@
   justify-content: flex-start;
   margin: 0 0 30px;
 
-  & input[type="checkbox"] {
+  & input[type='checkbox'] {
     height: 0;
     width: 0;
     display: none;
@@ -22,7 +22,7 @@
     margin: 0;
 
     &:after {
-      content: "";
+      content: '';
       position: absolute;
       top: 2px;
       left: 3px;
@@ -114,5 +114,6 @@
     font-weight: 400;
     font-size: 0.875rem;
     white-space: nowrap;
+    margin-right: 5px;
   }
 }

--- a/packages/Blaze-ui/src/module/_switches.scss
+++ b/packages/Blaze-ui/src/module/_switches.scss
@@ -14,8 +14,8 @@
     cursor: pointer;
     text-indent: -9999px;
     width: 40px;
-    height: 18px;
-    background: $grey;
+    height: 24px;
+    background: $blue-grey-200;
     display: block;
     border-radius: 20px;
     position: relative;
@@ -24,10 +24,10 @@
     &:after {
       content: '';
       position: absolute;
-      top: 2px;
+      top: 3px;
       left: 3px;
-      width: 14px;
-      height: 14px;
+      width: 18px;
+      height: 18px;
       background: $white;
       border-radius: 18px;
       transition: all 0.3s;
@@ -50,20 +50,20 @@
 
   &--primary {
     & input:checked + label {
-      background: lighten($primary-color, 30%);
+      background: $primary-color;
 
       &:after {
-        background: $primary-color;
+        background: lighten($primary-color, 30%);
       }
     }
   }
 
   &--secondary {
     & input:checked + label {
-      background: lighten($secondary-color, 30%);
+      background: $secondary-color;
 
       &:after {
-        background: $secondary-color;
+        background: lighten($secondary-color, 30%);
       }
     }
   }
@@ -84,6 +84,7 @@
     flex-direction: row;
   }
 
+  &--label--right,
   &--label-right {
     flex-direction: row-reverse;
     justify-content: flex-end;
@@ -98,7 +99,7 @@
   }
 
   & + .switch {
-    margin-left: 10px;
+    margin-top: -20px;
   }
 
   &__wrapper {
@@ -115,5 +116,6 @@
     font-size: 0.875rem;
     white-space: nowrap;
     margin-right: 5px;
+    margin-left: 5px;
   }
 }

--- a/packages/Switches/__tests__/__snapshots__/Switches.test.tsx.snap
+++ b/packages/Switches/__tests__/__snapshots__/Switches.test.tsx.snap
@@ -9,6 +9,11 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
       class="switch switch--label--right"
     >
       <div
+        class="switch__text"
+      >
+         Switch text
+      </div>
+      <div
         class="switch__item"
       >
         <input
@@ -23,15 +28,15 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
           toggle
         </label>
       </div>
+    </div>
+    <div
+      class="switch switch--label--right"
+    >
       <div
         class="switch__text"
       >
          Switch text
       </div>
-    </div>
-    <div
-      class="switch switch--label--right"
-    >
       <div
         class="switch__item"
       >
@@ -47,15 +52,15 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
           toggle
         </label>
       </div>
-      <div
-        class="switch__text"
-      >
-         Switch text
-      </div>
     </div>
     <div
       class="switch switch--label--right"
     >
+      <div
+        class="switch__text"
+      >
+         Disabled
+      </div>
       <div
         class="switch__item"
       >
@@ -71,11 +76,6 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
         >
           toggle
         </label>
-      </div>
-      <div
-        class="switch__text"
-      >
-         Disabled
       </div>
     </div>
   </div>

--- a/packages/Switches/__tests__/__snapshots__/Switches.test.tsx.snap
+++ b/packages/Switches/__tests__/__snapshots__/Switches.test.tsx.snap
@@ -9,11 +9,6 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
       class="switch switch--label--right"
     >
       <div
-        class="switch__text"
-      >
-         Switch text
-      </div>
-      <div
         class="switch__item"
       >
         <input
@@ -28,15 +23,15 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
           toggle
         </label>
       </div>
-    </div>
-    <div
-      class="switch switch--label--right"
-    >
       <div
         class="switch__text"
       >
          Switch text
       </div>
+    </div>
+    <div
+      class="switch switch--label--right"
+    >
       <div
         class="switch__item"
       >
@@ -52,15 +47,15 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
           toggle
         </label>
       </div>
+      <div
+        class="switch__text"
+      >
+         Switch text
+      </div>
     </div>
     <div
       class="switch switch--label--right"
     >
-      <div
-        class="switch__text"
-      >
-         Disabled
-      </div>
       <div
         class="switch__item"
       >
@@ -76,6 +71,11 @@ exports[`Switches component should be defined and renders correctly (snapshot) 1
         >
           toggle
         </label>
+      </div>
+      <div
+        class="switch__text"
+      >
+         Disabled
       </div>
     </div>
   </div>

--- a/packages/Switches/src/Switches.tsx
+++ b/packages/Switches/src/Switches.tsx
@@ -105,7 +105,6 @@ const Switches = ({
 
           return (
             <div className={switchClassNames} key={id}>
-              <div className="switch__text"> {label}</div>
               <div className="switch__item">
                 <input
                   readOnly
@@ -119,8 +118,9 @@ const Switches = ({
                   {...attrs}
                 />
                 <label htmlFor={id}>toggle</label>
-                <Tooltip {...tooltip} />
               </div>
+              <div className="switch__text"> {label}</div>
+              <Tooltip {...tooltip} />
             </div>
           );
         }),

--- a/packages/Switches/src/Switches.tsx
+++ b/packages/Switches/src/Switches.tsx
@@ -105,6 +105,8 @@ const Switches = ({
 
           return (
             <div className={switchClassNames} key={id}>
+              <Tooltip {...tooltip} />
+              <div className="switch__text"> {label}</div>
               <div className="switch__item">
                 <input
                   readOnly
@@ -119,8 +121,6 @@ const Switches = ({
                 />
                 <label htmlFor={id}>toggle</label>
               </div>
-              <div className="switch__text"> {label}</div>
-              <Tooltip {...tooltip} />
             </div>
           );
         }),

--- a/packages/Switches/stories/Switches.stories.tsx
+++ b/packages/Switches/stories/Switches.stories.tsx
@@ -62,6 +62,20 @@ storiesOf("Switches", module)
             options={multiple}
             onChange={() => ({})}
           />
+
+          <br />
+          <h4>Multiple with Reverse Label Position (Left)</h4>
+          <Switches
+            labelPosition="left"
+            tooltip={{
+              tooltipContent: (
+                <>tooltip on <em>click</em></>
+              ),
+              trigger: "click"
+            }}
+            options={multiple}
+            onChange={() => ({})}
+          />
         </div>
       </Suspense>
     );


### PR DESCRIPTION
### Checklist

- [x] Update title using conventional commits syntax
- [x] Add URL to ticket
- [x] Add appropriate label
- [ ] Add description explaining changes
- [ ] Add acceptance critiera
- [ ] (optional) Add screenshots / screen recordings
- [ ] (optional) Add testing instructions
- [ ] (optional) Add release instructions
- [ ] (optional) Add documentation in README.md file
- [ ] Add unit tests to ensure consistent code coverage
- [ ] Perform self-review of code changes
- [ ] Check Sonarcloud result
- [ ] Check whether unit tests are passing
- [ ] Add reviewers and notify them on Slack
- [ ] Update ticket status
- [ ] (optional) Delete branch after merge

## Ticket

[Ticket](https://byte-9.atlassian.net/browse/BZ2-4030?focusedCommentId=33678)

## Description

This update moves the tooltip on switches to the end of the label for better accessibility and improved user experience. Adjusted positioning ensures the tooltip aligns consistently.

## Acceptance critiera

n/a

## Screenshots / screen recordings

<img width="288" alt="Screenshot 2024-11-25 at 13 25 49" src="https://github.com/user-attachments/assets/7f55cb6e-268e-4e54-a119-4f6113cf593d">


## Testing instructions

n/a

## Release instructions

n/a
