### PR TITLE
fix: update tooltip to support both mouse and touch interactions

### DIFF
--- a/packages/Tooltip/src/Tooltip.tsx
+++ b/packages/Tooltip/src/Tooltip.tsx
@@ -158,10 +158,10 @@ const Tooltip: React.FC<TooltipProps> = ({
     >
       <span
         className={`tooltip ${disabled ? 'is-disabled' : ''}`}
-        onMouseEnter={isHoverTrigger && !disabled && !isHasTouch ? showTooltip : undefined}
+        onMouseEnter={isHoverTrigger && !disabled ? showTooltip : undefined}
         onTouchStart={isHoverTrigger && !disabled && isHasTouch ? showTooltip : undefined}
         onTouchEnd={isHoverTrigger && !disabled && isHasTouch ? hideTooltip : undefined}
-        onMouseLeave={isHoverTrigger && !disabled && !isHasTouch ? hideTooltip : undefined}
+        onMouseLeave={isHoverTrigger && !disabled ? hideTooltip : undefined}
         onClick={isClickTrigger && !disabled ? showTooltip : undefined}
         ref={tooltipWrapperRef}
       >
@@ -181,7 +181,7 @@ const Tooltip: React.FC<TooltipProps> = ({
                 ...styles,
               }}
               onMouseEnter={showTooltip}
-              onMouseLeave={isHoverTrigger && !disabled && !isHasTouch ? hideTooltip : undefined}
+              onMouseLeave={isHoverTrigger && !disabled ? hideTooltip : undefined}
             >
               <span className={`tooltip-buffer  tooltip-buffer--${newPosition.current}`} onMouseEnter={showTooltip} />
               {isClickTrigger && (


### PR DESCRIPTION
### Checklist

- [x] Update title using conventional commits syntax
- [x] Add URL to ticket
- [x] Add appropriate label
- [ ] Add description explaining changes
- [ ] Add acceptance critiera
- [ ] (optional) Add screenshots / screen recordings
- [ ] (optional) Add testing instructions
- [ ] (optional) Add release instructions
- [ ] (optional) Add documentation in README.md file
- [ ] Add unit tests to ensure consistent code coverage
- [ ] Perform self-review of code changes
- [ ] Check Sonarcloud result
- [ ] Check whether unit tests are passing
- [ ] Add reviewers and notify them on Slack
- [ ] Update ticket status
- [ ] (optional) Delete branch after merge

## Ticket

[Ticket](https://byte-9.atlassian.net/browse/BZ2-4180?focusedCommentId=34741)

## Description

This update modifies the Tooltip component to allow mouse events even when touch is supported. The onMouseEnter and onMouseLeave handlers no longer exclude touch devices, ensuring that hover functionality works across all devices. 

## Acceptance critiera

n/a

## Screenshots / screen recordings

n/a

## Testing instructions

n/a

## Release instructions

n/a
