### PR TITLE
chore: attach drag listeners to document for continuous tracking

### DIFF
--- a/packages/RangeFilter/src/logic.tsx
+++ b/packages/RangeFilter/src/logic.tsx
@@ -137,10 +137,10 @@ const RangeFilter = (selector: string, getMinMax: any) => {
     startX = eventTouch.pageX - xAxis;
     selectedTouch = this;
 
-    $(selector).addEventListener('mousemove', onMove);
-    $(selector).addEventListener('mouseup', onStop);
-    $(selector).addEventListener('touchmove', onMove, isPassiveSupported ? { passive: true } : false);
-    $(selector).addEventListener('touchend', onStop);
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onStop);
+    document.addEventListener('touchmove', onMove, isPassiveSupported ? { passive: true } : false);
+    document.addEventListener('touchend', onStop);
     document.addEventListener('click', onStop);
   }
 
@@ -216,10 +216,10 @@ const RangeFilter = (selector: string, getMinMax: any) => {
 
   const onStop = () => {
     document.removeEventListener('click', onStop);
-    $(selector).removeEventListener('mousemove', onMove);
-    $(selector).removeEventListener('mouseup', onStop);
-    $(selector).removeEventListener('touchmove', onMove);
-    $(selector).removeEventListener('touchend', onStop);
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onStop);
+    document.removeEventListener('touchmove', onMove);
+    document.removeEventListener('touchend', onStop);
 
     selectedTouch = null;
 


### PR DESCRIPTION
### Checklist

- [x] Update title using conventional commits syntax
- [x] Add URL to ticket
- [x] Add appropriate label
- [x] Add description explaining changes
- [ ] Add acceptance critiera
- [x] (optional) Add screenshots / screen recordings
- [ ] (optional) Add testing instructions
- [ ] (optional) Add release instructions
- [ ] (optional) Add documentation in README.md file
- [ ] Add unit tests to ensure consistent code coverage
- [ ] Perform self-review of code changes
- [x] Check Sonarcloud result
- [x] Check whether unit tests are passing
- [x] Add reviewers and notify them on Slack
- [ ] Update ticket status
- [ ] (optional) Delete branch after merge

## Ticket

https://byte-9.atlassian.net/browse/BZ2-4446

## Description

Move mousemove and mouseup event listeners from container to document to ensure drag operations continue when cursor moves outside component boundaries.

## Acceptance critiera

n/a

## Screenshots / screen recordings


https://github.com/user-attachments/assets/aeaad570-0576-47ae-9bf6-48630ca86045


https://github.com/user-attachments/assets/7079c4b4-1cc9-4d55-b3b7-f62299e7ce61



## Testing instructions

n/a

## Release instructions

n/a
