### PR TITLE
fix: paint track using selected min max

### DIFF
--- a/packages/RangeFilter/__tests__/__snapshots__/RangeFilter.test.tsx.snap
+++ b/packages/RangeFilter/__tests__/__snapshots__/RangeFilter.test.tsx.snap
@@ -19,20 +19,20 @@ exports[`RangeFilter component should be defined and renders correctly (snapshot
       class="range__filter _test_"
       id="_test_Range"
       max="20"
-      max-value="NaN"
+      max-value="10"
       min="0"
-      min-value="NaN"
+      min-value="5"
       step="1"
     >
       <div
         class="range__filter--left"
-        style="left: 0px;"
+        style="left: -6px;"
       >
         <span />
       </div>
       <div
         class="range__filter--right"
-        style="left: 0px;"
+        style="left: 13px;"
       >
         <span />
       </div>

--- a/packages/RangeFilter/src/RangeFilter.tsx
+++ b/packages/RangeFilter/src/RangeFilter.tsx
@@ -10,6 +10,8 @@ declare module 'react' {
     min?: string;
     max?: string;
     step?: string;
+    'min-value'?: string | number;
+    'max-value'?: string | number;
   }
 }
 
@@ -52,26 +54,31 @@ const RangeFilter: FunctionComponent<IRangeFilterProps> = ({
   }, [error]);
 
   useEffect(() => {
-    isContentLoaded(init, reInit);
-  }, []);
+    setInputs(value || {});
+  }, [value]);
 
-  const getMinMax = (minvalue: number, maxvalue: number) => {
-    const newValue = {
-      ...inputs,
-      minValue: minvalue,
-      maxValue: maxvalue
+  useEffect(() => {
+    const getMinMax = (minvalue: number, maxvalue: number) => {
+      const newValue = {
+        ...inputs,
+        minValue: minvalue,
+        maxValue: maxvalue
+      };
+      onChange({ value: newValue });
+      setInputs(newValue);
     };
-    onChange({ value: newValue });
-    setInputs(newValue);
-  };
 
-  const init = () => {
-    initRangeFilter(id, getMinMax);
-  };
+    const init = () => {
+      initRangeFilter(id, getMinMax);
+    };
 
-  const reInit = (time = 1000) => {
-    setTimeout(init, time);
-  };
+    const reInit = (time = 1000) => {
+      setTimeout(init, time);
+    };
+
+    isContentLoaded(init, reInit);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, value, onChange]);
 
   const modifierClassName: string = buildClassNames({
     [`form-field--${modifier}`]: !!modifier,
@@ -98,6 +105,8 @@ const RangeFilter: FunctionComponent<IRangeFilterProps> = ({
         min={min}
         max={max}
         step={step}
+        min-value={minValue}
+        max-value={maxValue}
         id={`${name}Range`}
         className={`range__filter ${id}`}
       >


### PR DESCRIPTION
### Checklist

- [x] Update title using conventional commits syntax
- [x] Add URL to ticket
- [x] Add appropriate label
- [x] Add description explaining changes
- [ ] Add acceptance critiera
- [x] (optional) Add screenshots / screen recordings
- [ ] (optional) Add testing instructions
- [ ] (optional) Add release instructions
- [ ] (optional) Add documentation in README.md file
- [ ] Add unit tests to ensure consistent code coverage
- [x] Perform self-review of code changes
- [ ] Check Sonarcloud result
- [ ] Check whether unit tests are passing
- [ ] Add reviewers and notify them on Slack
- [ ] Update ticket status
- [ ] (optional) Delete branch after merge

## Ticket

https://byte-9.atlassian.net/browse/BZ2-4446?search_id=bc535374-caeb-411e-9e99-f9122e35cdcf

## Description

The RangeFilter track rendered from extremes (0%/100%) instead of between the selected values.
Set min-value and max-value on the range container based on props

## Acceptance critiera

n/a

## Screenshots / screen recordings


https://github.com/user-attachments/assets/17ff9f5d-815b-4165-96a0-fd19ef9b4b61


https://github.com/user-attachments/assets/ded237e9-f493-4f48-a78c-352f8b27cfe8


## Testing instructions

n/a

## Release instructions

n/a
