### PR TITLE
fix: use selected only as initial state to prevent parent from resett…

### DIFF
--- a/packages/Tab/__tests__/Tab.test.tsx
+++ b/packages/Tab/__tests__/Tab.test.tsx
@@ -1,9 +1,8 @@
 import '@testing-library/jest-dom';
 
+import React from 'react';
 import { Tab, TabItem } from '../src';
 import { fireEvent, render, screen } from '@testing-library/react';
-
-import React from 'react';
 
 const TabComponent = (
   <Tab selected={1}>
@@ -41,28 +40,17 @@ describe('Tab component', () => {
 
     expect(screen.getByText('Advanced')).toBeInTheDocument();
     expect(() => screen.getByText('Conditional')).toThrow('Unable to find an element');
-    ;
   });
 
-  test('should update selected tab when selected prop changes', () => {
-    const { rerender } = render(
-      <Tab selected={0}>
+  test('should use selected prop as initial tab only', () => {
+    render(
+      <Tab selected={1}>
         <TabItem>Basic content here</TabItem>
         <TabItem title="Advanced">Advanced content here</TabItem>
         <TabItem title="Other">Other content here</TabItem>
       </Tab>
     );
 
-    expect(screen.getByText('Basic content here')).toBeInTheDocument();
-
-    rerender(
-      <Tab selected={2}>
-        <TabItem>Basic content here</TabItem>
-        <TabItem title="Advanced">Advanced content here</TabItem>
-        <TabItem title="Other">Other content here</TabItem>
-      </Tab>
-    );
-
-    expect(screen.getByText('Other content here')).toBeInTheDocument();
+    expect(screen.getByText('Advanced content here')).toBeInTheDocument();
   });
 });

--- a/packages/Tab/src/Tab/index.tsx
+++ b/packages/Tab/src/Tab/index.tsx
@@ -1,5 +1,5 @@
 import { ButtonView } from '@blaze-react/button';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { CustomIcon } from '@blaze-react/icon';
 import { TabItem } from '../TabItem';
 
@@ -14,16 +14,10 @@ interface ITabProps {
 export const Tab = ({ selected = 0, classes = '', children = 'No content' }: ITabProps): JSX.Element => {
   const [selectedValue, setSelected] = useState(selected);
 
-
-  useEffect(() => {
-    if (selectedValue !== selected) setSelected(selected)
-  }, [selected])
-
   const DeprecatedTabs = () => {
     console.warn(
-      'Usage of CSS classes will be deprecated in the near future. You should use Tailwind classes classes instead',
+      'Usage of CSS classes will be deprecated in the near future. You should use Tailwind classes instead',
     );
-
     return (
       <div className="tabs">
         <div className="tabs__list">
@@ -31,7 +25,6 @@ export const Tab = ({ selected = 0, classes = '', children = 'No content' }: ITa
             if (!React.isValidElement(child) || child.type !== TabItem) {
               return null;
             }
-
             const { props: { title = 'Unnamed tab' } = {} }: any = child;
             return (
               <ButtonView


### PR DESCRIPTION


### Checklist

- [x] Update title using conventional commits syntax
- [x] Add URL to ticket
- [x] Add appropriate label
- [ ] Add description explaining changes
- [ ] Add acceptance critiera
- [ ] (optional) Add screenshots / screen recordings
- [ ] (optional) Add testing instructions
- [ ] (optional) Add release instructions
- [ ] (optional) Add documentation in README.md file
- [x] Add unit tests to ensure consistent code coverage
- [x] Perform self-review of code changes
- [ ] Check Sonarcloud result
- [ ] Check whether unit tests are passing
- [x] Add reviewers and notify them on Slack
- [ ] Update ticket status
- [ ] (optional) Delete branch after merge

## Ticket

[Ticket](https://byte-9.atlassian.net/browse/BZ2-4634)

## Description

Fix tab reset: use selected only as the initial tab so the parent can’t overwrite the user’s choice on re-render. Update tests and Jest config so Tab tests run from the package.

## Acceptance critiera

n/a

## Screenshots / screen recordings

n/a

## Testing instructions

n/a

## Release instructions

n/a
