### PR TITLE
fix: use DeprecatedModal as default export for Blaze compatibility

### DIFF
--- a/packages/Modal/src/index.ts
+++ b/packages/Modal/src/index.ts
@@ -1,5 +1,5 @@
-import { Modal } from './controller/Modal';
+import { DeprecatedModal, Modal } from './controller/Modal';
 import { ModalView } from './view/ModalView';
 
-export default Modal;
-export { Modal, ModalView };
+export default DeprecatedModal;
+export { Modal, DeprecatedModal, ModalView };


### PR DESCRIPTION
### Checklist

- [ ] Update title using conventional commits syntax
- [ ] Add URL to ticket
- [ ] Add appropriate label
- [ ] Add description explaining changes
- [ ] Add acceptance critiera
- [ ] (optional) Add screenshots / screen recordings
- [ ] (optional) Add testing instructions
- [ ] (optional) Add release instructions
- [ ] (optional) Add documentation in README.md file
- [ ] Add unit tests to ensure consistent code coverage
- [ ] Perform self-review of code changes
- [ ] Check Sonarcloud result
- [ ] Check whether unit tests are passing
- [ ] Add reviewers and notify them on Slack
- [ ] Update ticket status
- [ ] (optional) Delete branch after merge

## Ticket

https://byte-9.atlassian.net/browse/BZ2-4634

## Description

Default export is now DeprecatedModal (BEM) instead of the new Tailwind Modal so existing Blaze modals render correctly without Tailwind styles.

## Acceptance critiera

n/a

## Screenshots / screen recordings

n/a

## Testing instructions

n/a

## Release instructions

n/a
